### PR TITLE
kola: fix cgroup parameters for docker

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -264,10 +264,9 @@ func dockerResources(c cluster.TestCluster) {
 		dCmd("--memory-reservation=10m"),
 		dCmd("--kernel-memory=10m"),
 		dCmd("--cpu-shares=100"),
-		dCmd("--cpu-period=1000"),
+		dCmd("--cpu-period=1000 --cpu-quota=1000"),
 		dCmd("--cpuset-cpus=0"),
 		dCmd("--cpuset-mems=0"),
-		dCmd("--cpu-quota=1000"),
 		dCmd("--blkio-weight=10"),
 		// none of these work in QEMU due to apparent lack of cfq for
 		// blkio in virtual block devices.


### PR DESCRIPTION
CI should run docker run with options together like `--cpu-quota=1000 --cpu-period=1000`.

That's because usually `--cpu-period` should work with `--cpu-quota`, as mentioned in https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources.

That will fix an issue of docker run hanging for a long time, when running with the systemd cgroup driver.