### PR TITLE
packet: Allow to set explicit URLs for the kernel and cpio files

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -153,6 +153,8 @@ func init() {
 	sv(&kola.PacketOptions.Facility, "packet-facility", "sjc1", "Packet facility code")
 	sv(&kola.PacketOptions.Plan, "packet-plan", "", "Packet plan slug (default board-dependent, e.g. \"baremetal_0\")")
 	sv(&kola.PacketOptions.InstallerImageBaseURL, "packet-installer-image-base-url", "", "Packet installer image base URL, non-https (default board-dependent, e.g. \"http://stable.release.flatcar-linux.net/amd64-usr/current\")")
+	sv(&kola.PacketOptions.InstallerImageKernelURL, "packet-installer-image-kernel-url", "", "Packet installer image kernel URL, (default packet-installer-image-base-url/flatcar_production_pxe.vmlinuz)")
+	sv(&kola.PacketOptions.InstallerImageCpioURL, "packet-installer-image-cpio-url", "", "Packet installer image cpio URL, (default packet-installer-image-base-url/flatcar_production_pxe_image.cpio.gz)")
 	sv(&kola.PacketOptions.ImageURL, "packet-image-url", "", "Packet image URL (default board-dependent, e.g. \"https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_packet_image.bin.bz2\")")
 	sv(&kola.PacketOptions.StorageURL, "packet-storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")
 

--- a/cmd/ore/packet/create-device.go
+++ b/cmd/ore/packet/create-device.go
@@ -43,6 +43,8 @@ func init() {
 	cmdCreateDevice.Flags().StringVar(&options.Plan, "plan", "", "plan slug (default board-dependent, e.g. \"baremetal_0\")")
 	cmdCreateDevice.Flags().StringVar(&options.Board, "board", "amd64-usr", "Container Linux board")
 	cmdCreateDevice.Flags().StringVar(&options.InstallerImageBaseURL, "installer-image-base-url", "", "installer image base URL, non-https (default board-dependent, e.g. \"http://stable.release.flatcar-linux.net/amd64-usr/current\")")
+	cmdCreateDevice.Flags().StringVar(&options.InstallerImageKernelURL, "installer-image-kernel-url", "", "Packet installer image kernel URL, (default installer-image-base-url/flatcar_production_pxe.vmlinuz)")
+	cmdCreateDevice.Flags().StringVar(&options.InstallerImageCpioURL, "installer-image-cpio-url", "", "Packet installer image cpio URL, (default installer-image-base-url/flatcar_production_pxe_image.cpio.gz)")
 	cmdCreateDevice.Flags().StringVar(&options.ImageURL, "image-url", "", "image base URL (default board-dependent, e.g. \"https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_packet_image.bin.bz2\")")
 	cmdCreateDevice.Flags().StringVar(&hostname, "hostname", "", "hostname to assign to device")
 	cmdCreateDevice.Flags().StringVar(&userDataPath, "userdata-file", "", "path to file containing userdata")


### PR DESCRIPTION
If appending the default file names to the base URL is not resulting in
the correct URL for the kernel and cpio files, there was no way to
specify the correct URLs for both explicitly.
Add two new options that default to the previous behavior if not used.

# How to use/testing done

```
bin/ore packet --api-key X --project X --storage-url X --gs-json-key X create-device --installer-image-kernel-url X --installer-image-cpio-url X --userdata-file X --hostname X
```