### PR TITLE
Add ability to make GCE images public, use it in ore and plume

### DIFF
--- a/cmd/ore/gcloud/create-image.go
+++ b/cmd/ore/gcloud/create-image.go
@@ -42,6 +42,7 @@ var (
 	createImageName    string
 	createImageLicense string
 	createImageForce   bool
+	createImagePublic  bool
 )
 
 func init() {
@@ -63,6 +64,8 @@ func init() {
 		"GCE Image license name")
 	cmdCreateImage.Flags().BoolVar(&createImageForce, "force",
 		false, "overwrite existing GCE images without prompt")
+	cmdCreateImage.Flags().BoolVar(&createImagePublic, "public",
+		false, "Set public ACLs on image")
 	GCloud.AddCommand(cmdCreateImage)
 }
 
@@ -134,5 +137,15 @@ func runCreateImage(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Creating GCE image failed: %v\n", err)
 		os.Exit(1)
+	}
+
+	// If requested, set the image ACL to public
+	if createImagePublic {
+		fmt.Printf("Setting image to have public access: %v\n", imageNameGCE)
+		err = api.SetImagePublic(imageNameGCE)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Marking GCE image with public ACLs failed: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/ore/gcloud/upload.go
+++ b/cmd/ore/gcloud/upload.go
@@ -42,6 +42,7 @@ var (
 	uploadBoard     string
 	uploadFile      string
 	uploadForce     bool
+	uploadPublic    bool
 )
 
 func init() {
@@ -53,6 +54,7 @@ func init() {
 		build+"/images/amd64-usr/latest/flatcar_production_gce.tar.gz",
 		"path_to_flatcar_image (build with: ./image_to_vm.sh --format=gce ...)")
 	cmdUpload.Flags().BoolVar(&uploadForce, "force", false, "overwrite existing GS and GCE images without prompt")
+	cmdUpload.Flags().BoolVar(&uploadPublic, "public", false, "Set public ACLs on image")
 	GCloud.AddCommand(cmdUpload)
 }
 
@@ -171,6 +173,16 @@ func runUpload(cmd *cobra.Command, args []string) {
 			fmt.Printf("Image %v sucessfully created in GCE\n", imageNameGCE)
 		default:
 			fmt.Println("Skipped GCE image creation")
+		}
+
+		// If requested, set the image ACL to public
+		if uploadPublic {
+			fmt.Printf("Setting image to have public access: %v\n", imageNameGCE)
+			err = api.SetImagePublic(imageNameGCE)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Marking GCE image with public ACLs failed: %v\n", err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/cmd/plume/release.go
+++ b/cmd/plume/release.go
@@ -282,6 +282,13 @@ func doGCE(ctx context.Context, client *http.Client, src *storage.Bucket, spec *
 		imageLink = gceUploadImage(spec, api, obj, name, desc)
 	}
 
+	// Released images should be public
+	fmt.Printf("Setting image to have public access: %v\n", name)
+	err = api.SetImagePublic(name)
+	if err != nil {
+		plog.Fatalf("Marking GCE image with public ACLs failed: %v", err)
+	}
+
 	if spec.GCE.Publish != "" {
 		obj := gs.Object{
 			Name:        src.Prefix() + spec.GCE.Publish,

--- a/platform/api/gcloud/image.go
+++ b/platform/api/gcloud/image.go
@@ -148,3 +148,34 @@ func (a *API) DeleteImage(name string) (*Pending, error) {
 	opReq := a.compute.GlobalOperations.Get(a.options.Project, op.Name)
 	return a.NewPending(op.Name, opReq), nil
 }
+
+// https://cloud.google.com/compute/docs/images/managing-access-custom-images#share-images-publicly
+func (a *API) SetImagePublic(name string) error {
+	// The IAM policy binding to allow all authenticated users to
+	// use an image
+	publicbinding := &compute.Binding{
+		Members: []string{"allAuthenticatedUsers"},
+		Role:    "roles/compute.imageUser",
+	}
+
+	// Get the current policy for the image
+	policy, err := a.compute.Images.GetIamPolicy(a.options.Project, name).Do()
+	if err != nil {
+		return fmt.Errorf("Getting image %s IAM policy failed: %v", name, err)
+	}
+
+	// Add entries to the policy to make the image public.
+	policy.Bindings = append(policy.Bindings, publicbinding)
+
+	// Make the call to make it public. If the image is already
+	// public for whatever reason doing this has no effect.
+	globalsetpolicyrequest := &compute.GlobalSetPolicyRequest{
+		Policy: policy,
+	}
+	_, err = a.compute.Images.SetIamPolicy(
+		a.options.Project, name, globalsetpolicyrequest).Do()
+	if err != nil {
+		return fmt.Errorf("Setting image %s IAM policy failed: %v", name, err)
+	}
+	return nil
+}


### PR DESCRIPTION
# Add ability to make GCE images public, use it in ore and plume

This change is based on coreos/coreos-assembler@f5d422d (PR: coreos/coreos-assembler#1610)

It adds support for marking images with public ACLs when they are created, and uses this functionality from ore upload, ore create-image and plume release. In the ore subcommands, this is gated with a --public flag, in the plume subcommand, the image is always made public.

# How to use

Build ore and plume with this change. Run `ore gcloud create-image --public` or `plume release`. Verify that the image was set to public.

This requires the service account to have access to `compute.images.getIamPolicy` and `compute.images.setIamPolicy`.

# Testing done

Tested uploading with ore:

```
./bin/ore gcloud create-image --project kinvolk-public --board amd64-usr --family flatcar-alpha --license flatcar-container-linux --source-root "gs://flatcar-jenkins/alpha/boards" --version 2705.0.0 --json-key ../../.creds/gce-image-uploader.json --public 
Creating image in GCE: flatcar-alpha-2705-0-0...
Setting image to have public access: flatcar-alpha-2705-0-0
```

Verified that the image was indeed public, then deleted it, to run the command with plume:


```
./bin/plume release --debug --board amd64-usr --channel alpha --version 2705.0.0 --gce-json-key ../../.creds/gce-service-account.json --gce-release-key ../../.creds/gce-image-uploader.json
2020-11-30T15:28:58Z cli: Started logging at level DEBUG
2020-11-30T15:28:58Z storage: Fetching gs://flatcar-jenkins/alpha/boards/amd64-usr/2705.0.0/
2020-11-30T15:28:59Z storage: Found 376 objects under gs://flatcar-jenkins/alpha/boards/amd64-usr/2705.0.0/
2020-11-30T15:28:59Z plume: Creating GCE image flatcar-alpha-2705-0-0
2020-11-30T15:29:00Z platform/api/gcloud: Creating image "flatcar-alpha-2705-0-0" from "https://www.googleapis.com/download/storage/v1/b/flatcar-jenkins/o/alpha%2Fboards%2Famd64-usr%2F2705.0.0%2Fflatcar_production_gce.tar.gz?generation=1606426653733074&alt=media"
2020-11-30T15:29:01Z plume: Waiting for image creation to finish...
2020-11-30T15:29:01Z plume: Image creation is running. 
2020-11-30T15:29:04Z plume: Image creation is running. 
2020-11-30T15:29:08Z plume: Image creation is running. 
2020-11-30T15:29:11Z plume: Image creation is running. 
2020-11-30T15:29:15Z plume: Image creation is running. 
2020-11-30T15:29:18Z plume: Image creation is running. 
2020-11-30T15:29:21Z plume: Image creation is running. 
2020-11-30T15:29:25Z plume: Image creation is running. 
2020-11-30T15:29:28Z plume: Image creation is running. 
2020-11-30T15:29:32Z plume: Image creation is running. 
2020-11-30T15:29:35Z plume: Image creation is running. 
2020-11-30T15:29:39Z plume: Image creation is running. 
2020-11-30T15:29:42Z plume: Image creation is running. 
2020-11-30T15:29:46Z plume: Image creation is running. 
2020-11-30T15:29:49Z plume: Image creation is running. 
2020-11-30T15:29:52Z plume: Image creation is running. 
2020-11-30T15:29:56Z plume: Image creation is running. 
2020-11-30T15:29:59Z plume: Image creation is running. 
2020-11-30T15:30:02Z plume: Image creation is running. 
2020-11-30T15:30:06Z plume: Image creation is running. 
2020-11-30T15:30:09Z plume: Image creation is done:   100%
2020-11-30T15:30:09Z plume: Success!
Setting image to have public access: flatcar-alpha-2705-0-0
2020-11-30T15:30:10Z plume: GCE image name publishing disabled.
2020-11-30T15:30:10Z plume: Deprecating old image flatcar-alpha-2697-0-0
2020-11-30T15:30:11Z plume: Waiting on 1 operations.
2020-11-30T15:30:12Z plume: No Azure profile defined, skipping.
2020-11-30T15:30:12Z plume: AWS image creation disabled.
```
