### PR TITLE
cmd/cork,sdk: introduce --repo-branch option to cork

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -28,6 +28,16 @@ import (
 
 const (
 	coreosManifestURL = "https://github.com/flatcar-linux/manifest.git"
+	// Set repoUpstreamBranch to "maint", until the upstream repo >= v2.10
+	// could be available in ordinary SDK environments. That is to avoid
+	// incompatibility issue of an old repo tool not being able to work with
+	// the default "stable" branch of the repo tool,
+	// https://gerrit.googlesource.com/git-repo/+/refs/heads/stable,
+	// which does not support python2 any more. OTOH its "maint" branch still
+	// supports python2. In the long term, we should update "dev-vcs/repo"
+	// in Flatcar SDK to v2.10 with python3, and set the default branch back
+	// to "stable".
+	repoUpstreamBranch = "maint"
 )
 
 var (
@@ -42,6 +52,7 @@ var (
 	manifestURL    string
 	manifestName   string
 	manifestBranch string
+	repoBranch     string
 	repoVerify     bool
 	sigVerify      bool
 
@@ -115,6 +126,8 @@ func init() {
 		"manifest-branch", "flatcar-master", "Manifest git repo branch")
 	creationFlags.StringVar(&manifestName,
 		"manifest-name", "default.xml", "Manifest file name")
+	creationFlags.StringVar(&repoBranch,
+		"repo-branch", repoUpstreamBranch, "Branch name to be used from the upstream git repo of repo tool")
 	creationFlags.BoolVar(&repoVerify,
 		"verify", false, "Check repo tree and release manifest match")
 	creationFlags.StringVar(&verifyKeyFile,
@@ -249,7 +262,7 @@ func unpackChroot(replace bool) {
 }
 
 func updateRepo() {
-	if err := sdk.RepoInit(chrootName, manifestURL, manifestBranch, manifestName, useHostDNS); err != nil {
+	if err := sdk.RepoInit(chrootName, manifestURL, manifestBranch, manifestName, repoBranch, useHostDNS); err != nil {
 		plog.Fatalf("repo init failed: %v", err)
 	}
 

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -128,7 +128,7 @@ func BuildImageDir(board, version string) string {
 	return filepath.Join(BuildRoot(), "images", board, dir)
 }
 
-func RepoInit(chroot, url, branch, name string, useHostDNS bool) error {
+func RepoInit(chroot, url, manifestBranch, name, repoBranch string, useHostDNS bool) error {
 	return enterChroot(enter{
 		Chroot:     chroot,
 		CmdDir:     chrootRepoRoot,
@@ -136,8 +136,9 @@ func RepoInit(chroot, url, branch, name string, useHostDNS bool) error {
 		Cmd: []string{"--",
 			"repo", "init",
 			"--manifest-url", url,
-			"--manifest-branch", branch,
+			"--manifest-branch", manifestBranch,
 			"--manifest-name", name,
+			"--repo-branch", repoBranch,
 		}})
 }
 


### PR DESCRIPTION
Introduce a new option `--repo-branch` to `cork create` and `update`.
The option allows users to specify an arbitrary branch name passed to the `repo init` command.

Also set the default branch name of repo to `maint`, until the upstream repo >= v2.10 could be available in ordinary SDK environments.
That is to avoid incompatibility issue of an old repo tool not being able to work with the default [`stable`](https://gerrit.googlesource.com/git-repo/+/refs/heads/stable) branch of the repo tool, which does not support python2 any more.
On the other hand, its [`maint`](https://gerrit.googlesource.com/git-repo/+/refs/heads/maint) branch still supports python2.

In the long term, we should update `dev-vcs/repo` in Flatcar SDK to v2.10 with python3, and set the default branch back to `stable`.

## How to use

```
./build cork
```

Working:

```
./bin/cork create --repo-branch=maint
```

Not working yet with repo <= 2.9.
```
./bin/cork create --repo-branch=stable
```