### PR TITLE
Improve AWS subcommands in ore, support AWS Pro downloading in cork, adjust LTS handling in plume

### DIFF
--- a/cmd/cork/downloadimage.go
+++ b/cmd/cork/downloadimage.go
@@ -81,6 +81,7 @@ func (platforms *platformList) Set(value string) error {
 	// Maps names of platforms to a list of file suffixes to download.
 	platformMap := map[string][]string{
 		"aws":       {"_ami_vmdk_image.vmdk.bz2"},
+		"aws_pro":   {"_ami_vmdk_pro_image.vmdk.bz2"},
 		"esx":       {"_vmware_ova.ova"},
 		"gce":       {"_gce.tar.gz"},
 		"qemu":      {"_image.bin.bz2"},

--- a/cmd/ore/aws/delete.go
+++ b/cmd/ore/aws/delete.go
@@ -1,0 +1,89 @@
+// Copyright 2020 Kinvolk GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdDelete = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete AWS images",
+		Long: `Delete a Flatcar image by deleting any file from S3, the EC2 snapshot, and the AMI.
+
+An error code is returned when something was found but couldn't be removed. No error code is returned when nothing was found.
+`,
+		Example: `  ore aws delete --region=us-east-1 \
+	  --ami-name="myimage-1.2.3" --name="myimage-1.2.3" --file=flatcar_production_ami_vmdk_image.vmdk --bucket s3://flatcar-dev/myimages/`,
+		RunE: runDelete,
+	}
+
+	deleteBucket    string
+	deleteImageName string
+	deleteBoard     string
+	deleteFile      string
+	deleteAMIName   string
+)
+
+func init() {
+	AWS.AddCommand(cmdDelete)
+	cmdDelete.Flags().StringVar(&deleteBucket, "bucket", "", "s3://bucket/prefix/ (defaults to a regional bucket and prefix defaults to $USER/board/name)")
+	cmdDelete.Flags().StringVar(&deleteImageName, "name", "", "name of image EC2 snapshot to delete")
+	cmdDelete.Flags().StringVar(&deleteBoard, "board", "amd64-usr", "board used for naming with default prefix and AMI architecture")
+	cmdDelete.Flags().StringVar(&deleteFile, "file", defaultUploadFile(), "name of image file object in the bucket")
+	cmdDelete.Flags().StringVar(&deleteAMIName, "ami-name", "", "name of the AMI to create (default: Container-Linux-$USER-$VERSION)")
+}
+
+func runDelete(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		fmt.Fprintf(os.Stderr, "Unrecognized args in aws delete cmd: %v\n", args)
+		os.Exit(2)
+	}
+
+	amiName := deleteAMIName
+
+	switch deleteBoard {
+	case "amd64-usr":
+	case "arm64-usr":
+		if !strings.HasSuffix(amiName, "-arm64") {
+			amiName = amiName + "-arm64"
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "No AMI name suffix known for board %q\n", deleteBoard)
+		os.Exit(1)
+	}
+
+	s3URL, err := defaultBucketURL(deleteBucket, deleteImageName, deleteBoard, deleteFile, region)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	plog.Debugf("S3 object: %v\n", s3URL)
+	s3BucketName := s3URL.Host
+	s3ObjectPath := strings.TrimPrefix(s3URL.Path, "/")
+
+	err = API.RemoveImage(amiName, deleteImageName, s3BucketName, s3ObjectPath, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to delete: %v\n", err)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/cmd/ore/aws/upload.go
+++ b/cmd/ore/aws/upload.go
@@ -207,7 +207,7 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	s3ObjectPath := strings.TrimPrefix(s3URL.Path, "/")
 
 	if uploadForce {
-		API.RemoveImage(amiName, s3BucketName, s3ObjectPath, nil)
+		API.RemoveImage(amiName, imageName, s3BucketName, s3ObjectPath, nil)
 	}
 
 	// if no snapshot was specified, check for an existing one or a

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -144,7 +144,7 @@ var (
 			Boards:         []string{"amd64-usr"},
 			Destinations:   []storageSpec{},
 			GCE:            newGceSpec("lts", lts_desc),
-			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "", lts_desc),
+			Azure:          azureSpec{},
 			AzurePremium:   newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "_pro", lts_desc),
 			AWS:            awsSpec{},
 		},

--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -146,7 +146,7 @@ var (
 			GCE:            newGceSpec("lts", lts_desc),
 			Azure:          newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "", lts_desc),
 			AzurePremium:   newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "_pro", lts_desc),
-			AWS:            newAWSSpec(),
+			AWS:            awsSpec{},
 		},
 		"developer": channelSpec{
 			BaseURL:        "gs://flatcar-jenkins/developer/developer/boards",

--- a/cmd/plume/prerelease.go
+++ b/cmd/plume/prerelease.go
@@ -423,7 +423,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imagePath s
 	}
 
 	if force {
-		err := api.RemoveImage(imageName, part.Bucket, s3ObjectPath, destRegions)
+		err := api.RemoveImage(imageName, imageName, part.Bucket, s3ObjectPath, destRegions)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/plume/prune.go
+++ b/cmd/plume/prune.go
@@ -218,7 +218,7 @@ func pruneAWS(ctx context.Context, spec *channelSpec) {
 					// Remove -hvm from the name, as the snapshots don't include that.
 					imageName := strings.TrimSuffix(*image.Name, "-hvm")
 
-					err := api.RemoveImage(imageName, part.Bucket, s3ObjectPath, nil)
+					err := api.RemoveImage(imageName, imageName, part.Bucket, s3ObjectPath, nil)
 					if err != nil {
 						plog.Fatalf("couldn't prune image %v: %v", *image.Name, err)
 					}

--- a/platform/api/aws/images.go
+++ b/platform/api/aws/images.go
@@ -349,7 +349,7 @@ func (a *API) deregisterImageIfExists(name string) error {
 }
 
 // Remove all uploaded data associated with an AMI, also in other given regions.
-func (a *API) RemoveImage(name, s3BucketName, s3ObjectPath string, otherRegions []string) error {
+func (a *API) RemoveImage(amiName, imageName, s3BucketName, s3ObjectPath string, otherRegions []string) error {
 	err := a.DeleteObject(s3BucketName, s3ObjectPath)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
@@ -370,18 +370,18 @@ func (a *API) RemoveImage(name, s3BucketName, s3ObjectPath string, otherRegions 
 		if err != nil {
 			return err
 		}
-		plog.Infof("Trying to deregister %s in %s", name, region)
+		plog.Infof("Trying to deregister %s in %s", amiName, region)
 
-		err = aa.deregisterImageIfExists(name + "-hvm")
+		err = aa.deregisterImageIfExists(amiName + "-hvm")
 		if err != nil {
 			return err
 		}
-		err = aa.deregisterImageIfExists(name)
+		err = aa.deregisterImageIfExists(amiName)
 		if err != nil {
 			return err
 		}
 
-		snapshot, err := aa.FindSnapshot(name)
+		snapshot, err := aa.FindSnapshot(imageName)
 		if err != nil {
 			return err
 		}
@@ -394,6 +394,8 @@ func (a *API) RemoveImage(name, s3BucketName, s3ObjectPath string, otherRegions 
 			} else {
 				plog.Infof("Deleted existing snapshot %s", snapshot.SnapshotID)
 			}
+		} else {
+			plog.Warningf("No snapshot was found")
 		}
 	}
 


### PR DESCRIPTION
- cmd/plume: Disable AMI creation for the LTS channel
    The AMIs were not published anyway and just used for testing.
- cmd/cork: Support downloading AWS Pro images
    The AWS Pro images are a different OEM type with a _pro suffix.
- cmd/ore: Delete existing snapshot when --force is used
    A mismatched snapshot name resulted in "ore aws upload --force" not
    really reuploading but just reusing the existing AMI.
    Use the correct snapshot name to ensure that --force works.
- cmd/plume: Only build Azure Pro for LTS
- cmd/ore: Add new "aws delete" command to remove an image
    An image uploaded by "ore aws upload" could only be deleted manually.
    Add a subcommand to delete the image again.

# How to use

In conjunction with https://github.com/kinvolk/flatcar-scripts/pull/106 and from Jenkins.

# Testing done

Tested only uploading and deleting regular AWS images:

```
./cork download-image --cache-dir=/var/tmp --platform=aws --root=gs://flatcar-jenkins/stable/boards/amd64-usr/2605.9.0
./ore -d aws upload --region=eu-central-1 --ami-name=myami --ami-description="Custom Flatcar Test" --name=myimage --file=/var/tmp/flatcar_production_ami_vmdk_image.vmdk --bucket s3://flatcar-dev/myprefix/ --force
./ore -d aws delete --region=eu-central-1 --ami-name=myami --name=myimage --file=/var/tmp/flatcar_production_ami_vmdk_image.vmdk --bucket s3://flatcar-dev/myprefix/
```
