### PR TITLE
kola/tests/misc/network.go: Allow systemd-resolved to run

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -136,6 +136,8 @@ func NetworkListeners(c cluster.TestCluster) {
 		{"tcp", "10010", "containerd"},     // containerd
 		{"udp", "68", "systemd-networkd"},  // dhcp6-client
 		{"udp", "546", "systemd-networkd"}, // bootpc
+		{"tcp", "53", "systemd-resolved"},  // DNS server
+		{"udp", "53", "systemd-resolved"},  // DNS server
 		{"udp", "*", "systemd-timesyncd"},  // NTP client (random client ports)
 	}
 	checkList := func() error {


### PR DESCRIPTION
As local DNS server systemd-resolved listens on 127.0.0.53:53 accepting
both TCP and UDP connections. It should be used not only for its caching
and other features but because otherwise the per-interface DNS servers
get merged into one global /etc/resolve.conf file.
See https://github.com/kinvolk/Flatcar/issues/285

# How to use/testing done

```
wget https://storage.googleapis.com/flatcar-jenkins/developer/developer/boards/amd64-usr/2020.12.07+dev-flatcar-master-1604/flatcar_production_qemu_image.img.bz2
lbunzip2 flatcar_production_qemu_image.img.bz2
sudo ./kola run --board=amd64-usr --channel=alpha --parallel=1 --platform=qemu --qemu-bios=bios-256k.bin --qemu-image flatcar_production_qemu_image.img cl.network.listeners
```


