### PR TITLE
kola/tests/misc/network.go: Disallow the CRI plugin to listen on TCP

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -133,7 +133,6 @@ NextProcess:
 func NetworkListeners(c cluster.TestCluster) {
 	expectedListeners := []listener{
 		{"tcp", "22", "systemd"},           // ssh
-		{"tcp", "10010", "containerd"},     // containerd
 		{"udp", "68", "systemd-networkd"},  // dhcp6-client
 		{"udp", "546", "systemd-networkd"}, // bootpc
 		{"udp", "*", "systemd-timesyncd"},  // NTP client (random client ports)


### PR DESCRIPTION
The containerd cri plugin used a TCP port in the past and for Edge it
was allowed to be opened.
Remove this rule because containerd should not listen on TCP anymore
(and for the Alpha, Beta, Stable channels never did).

# How to use

# Testing done
