### PR TITLE
kola/tests/misc/network.go: Allow the containerd CRI plugin to listen

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -136,6 +136,7 @@ func NetworkListeners(c cluster.TestCluster) {
 		{"udp", "68", "systemd-networkd"},  // dhcp6-client
 		{"udp", "546", "systemd-networkd"}, // bootpc
 		{"udp", "*", "systemd-timesyncd"},  // NTP client (random client ports)
+		{"tcp", "*", "containerd"},         // CNI streaming API
 	}
 	checkList := func() error {
 		return checkListeners(c, expectedListeners)


### PR DESCRIPTION
The CRI plugin listens on a random port to serve the streaming API.


