### PR TITLE
cmd/plume: Don't try to publish GCE LTS images

### DIFF
--- a/cmd/plume/containerlinux.go
+++ b/cmd/plume/containerlinux.go
@@ -143,7 +143,7 @@ var (
 			BasePrivateURL: "gs://flatcar-jenkins-private/lts/boards",
 			Boards:         []string{"amd64-usr"},
 			Destinations:   []storageSpec{},
-			GCE:            newGceSpec("lts", lts_desc),
+			GCE:            gceSpec{},
 			Azure:          azureSpec{},
 			AzurePremium:   newAzureSpec(azureEnvironments, "publish", "Flatcar LTS", "_pro", lts_desc),
 			AWS:            awsSpec{},


### PR DESCRIPTION
This does not work at the moment and will only be done for GCE Pro.
