### PR TITLE
kola: do not test Docker torcx profile tests for alpha

### DIFF
--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -38,7 +38,7 @@ storage:
       mode: 0644
 `),
 		Distros:         []string{"cl"},
-		ExcludeChannels: []string{"edge"},
+		ExcludeChannels: []string{"alpha", "edge"},
 	})
 	register.Register(&register.Test{
 		Run:         dockerTorcxFlagFileCloudConfig,
@@ -52,7 +52,7 @@ write_files:
 `),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
-		ExcludeChannels:  []string{"edge"},
+		ExcludeChannels:  []string{"alpha", "edge"},
 	})
 }
 


### PR DESCRIPTION
Since the Docker 1.12 will be soon removed from Alpha, we need to exclude `alpha` from the list of channels, where tests run on hard-coded strings for Docker 1.12 in torcx profiles.