### PR TITLE
kola/tests/flannel: use docker0's interface address as destination

### DIFF
--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -94,13 +94,13 @@ func mach2bip(c cluster.TestCluster, m platform.Machine, ifname string) (string,
 }
 
 // ping sends icmp packets from machine a to b using the ping tool.
-func ping(c cluster.TestCluster, a, b platform.Machine, ifname string) {
-	srcip, err := mach2bip(c, a, ifname)
+func ping(c cluster.TestCluster, a, b platform.Machine, ifnameA, ifnameB string) {
+	srcip, err := mach2bip(c, a, ifnameA)
 	if err != nil {
 		c.Fatalf("failed to get docker bridge ip #1: %v", err)
 	}
 
-	dstip, err := mach2bip(c, b, ifname)
+	dstip, err := mach2bip(c, b, ifnameB)
 	if err != nil {
 		c.Fatalf("failed to get docker bridge ip #2: %v", err)
 	}
@@ -129,7 +129,9 @@ func udp(c cluster.TestCluster) {
 		c.Fatalf("cluster health: %v", err)
 	}
 
-	ping(c, machs[0], machs[2], "flannel0")
+	// ping the docker0 address .1/24 instead of the flannel0 address .0/32
+	// because it does not work after a flanneld restart
+	ping(c, machs[0], machs[2], "flannel0", "docker0")
 }
 
 // VXLAN tests that flannel can send packets using the vxlan backend.
@@ -141,5 +143,5 @@ func vxlan(c cluster.TestCluster) {
 		c.Fatalf("cluster health: %v", err)
 	}
 
-	ping(c, machs[0], machs[2], "flannel.1")
+	ping(c, machs[0], machs[2], "flannel.1", "flannel.1")
 }


### PR DESCRIPTION
In case flanneld restarted, it does not work anymore to ping its
bridge address .0/32 attached to the flannel0 interface but only the
other addresses like .1/24 on docker0. This is the case with rkt
already but now with docker we have an additional restart of flanneld
when docker gets restarted to apply the flannel settings. Now this
problem directly pops up but before it would normally not happen in
the test.


# How to use/testing done

Run kola test `cl.flannel.udp` on Equinix Metal or another cloud platform (not QEMU)

