### PR TITLE
cork: Apply patches with a dummy committer

### DIFF
--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -187,7 +187,7 @@ func ApplyPatch(chroot string, useHostDNS bool, repositoryPath, patchPath string
 		return err
 	}
 
-	args := []string{"--", "git", "am", "-3", filepath.Join(chrootRepoRoot, targetName)}
+	args := []string{"GIT_COMMITTER_NAME=Flatcar Buildbot", "GIT_COMMITTER_EMAIL=buildbot@flatcar-linux.org", "--", "git", "am", "-3", filepath.Join(chrootRepoRoot, targetName)}
 	err = enterChroot(enter{
 		Chroot:     chroot,
 		CmdDir:     filepath.Join(chrootRepoRoot, repositoryPath),


### PR DESCRIPTION
When no git configuration is found in the SDK chroot, git will error
out because it can't set the committer when applying the patches.
Always specify a default committer for applying patches.

Follow-up after https://github.com/kinvolk/mantle/pull/163

Tested by running and checking the commit with `git show --format=full` to show `Commit: Flatcar Buildbot …`