### PR TITLE
kola: Exclude beta from Docker torcx profiles tests

### DIFF
--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -38,7 +38,7 @@ storage:
       mode: 0644
 `),
 		Distros:         []string{"cl"},
-		ExcludeChannels: []string{"alpha", "edge"},
+		ExcludeChannels: []string{"alpha", "beta", "edge"},
 	})
 	register.Register(&register.Test{
 		Run:         dockerTorcxFlagFileCloudConfig,
@@ -52,7 +52,7 @@ write_files:
 `),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
-		ExcludeChannels:  []string{"alpha", "edge"},
+		ExcludeChannels:  []string{"alpha", "beta", "edge"},
 	})
 }
 


### PR DESCRIPTION
WIth the Alpha to Beta transition, Docker 1.12 is removed from Beta, and we would need to remove the beta from testing Docker 1.12 torcx profiles.