### PR TITLE
platform: allow CLC templating for dynamic IP address insertion

### DIFF
--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -38,7 +38,7 @@ func init() {
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery`),
 		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu", "qemu-unpriv"},
+		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 
 	register.Register(&register.Test{
@@ -54,7 +54,7 @@ etcd:
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery
 `),
-		ExcludePlatforms: []string{"esx", "qemu", "qemu-unpriv"}, // etcd-member requires ct rendering
+		ExcludePlatforms: []string{"esx", "qemu-unpriv"}, // etcd-member requires ct rendering and networking
 		Distros:          []string{"cl"},
 	})
 
@@ -73,7 +73,7 @@ etcd:
   initial_advertise_peer_urls: http://127.0.0.1:2380
 `),
 		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu", "qemu-unpriv"},
+		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 }
 

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -63,7 +63,7 @@ func init() {
 		ClusterSize:      3,
 		Name:             "cl.flannel.udp",
 		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu", "qemu-unpriv"},
+		ExcludePlatforms: []string{"qemu-unpriv"},
 		UserData:         flannelConf.Subst("$type", "udp"),
 	})
 
@@ -72,7 +72,7 @@ func init() {
 		ClusterSize:      3,
 		Name:             "cl.flannel.vxlan",
 		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu", "qemu-unpriv"},
+		ExcludePlatforms: []string{"qemu-unpriv"},
 		UserData:         flannelConf.Subst("$type", "vxlan"),
 	})
 }

--- a/kola/tests/ignition/security.go
+++ b/kola/tests/ignition/security.go
@@ -80,7 +80,7 @@ func init() {
 		// ESX: Currently Ignition does not support static IPs during the initramfs
 		// DO: https://github.com/coreos/bugs/issues/2205
 		// Packet & QEMU: https://github.com/coreos/ignition/issues/645
-		ExcludePlatforms: []string{"esx", "do", "packet", "qemu"},
+		ExcludePlatforms: []string{"esx", "do", "packet"},
 		Distros:          []string{"cl", "fcos", "rhcos"},
 	})
 }

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -46,7 +46,7 @@ etcd:
   listen_peer_urls:            http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery`),
 		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"qemu", "qemu-unpriv"},
+		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 	register.Register(&register.Test{
 		Name:        "coreos.locksmith.reboot",

--- a/platform/local/dnsmasq.go
+++ b/platform/local/dnsmasq.go
@@ -89,6 +89,11 @@ leasefile-ro
 log-facility=-
 pid-file=
 
+# hardcode DNS servers to avoid using systemd-resolved on the unreachable 127.0.0.53
+dhcp-option=6,1.1.1.1,1.0.0.1,8.8.8.8
+no-resolv
+no-hosts
+
 enable-ra
 
 # point NTP at this host (0.0.0.0 and :: are special)

--- a/platform/local/flight.go
+++ b/platform/local/flight.go
@@ -50,7 +50,7 @@ func NewLocalFlight(opts *platform.Options, platformName platform.Name) (*LocalF
 	}
 
 	nsdialer := network.NewNsDialer(nshandle)
-	bf, err := platform.NewBaseFlightWithDialer(opts, platformName, "", nsdialer)
+	bf, err := platform.NewBaseFlightWithDialer(opts, platformName, "custom", nsdialer)
 	if err != nil {
 		nshandle.Close()
 		return nil, fmt.Errorf("creating new base flight failed: %v", err)

--- a/platform/machine/esx/cluster.go
+++ b/platform/machine/esx/cluster.go
@@ -90,9 +90,11 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-Environment=OUTPUT=/run/metadata/coreos
+Environment=OUTPUT=/run/metadata/flatcar
 ExecStart=/usr/bin/mkdir --parent /run/metadata
-ExecStart=/usr/bin/bash -c 'echo "COREOS_CUSTOM_PRIVATE_IPV4=$(ip addr show ens192 | grep "inet 10." | grep -Po "inet \K[\d.]+")\nCOREOS_CUSTOM_PUBLIC_IPV4=$(ip addr show ens192 | grep -v "inet 10." | grep -Po "inet \K[\d.]+")" > ${OUTPUT}'`, false)
+ExecStart=/usr/bin/bash -c 'echo "COREOS_CUSTOM_PRIVATE_IPV4=$(ip addr show ens192 | grep "inet 10." | grep -Po "inet \K[\d.]+")\nCOREOS_CUSTOM_PUBLIC_IPV4=$(ip addr show ens192 | grep -v "inet 10." | grep -Po "inet \K[\d.]+")" > ${OUTPUT}'
+ExecStartPost=/usr/bin/ln -fs /run/metadata/flatcar /run/metadata/coreos
+`, false)
 
 	instance, err := ec.flight.api.CreateDevice(ec.vmname(), conf, ipPairMaybe)
 	if err != nil {

--- a/platform/machine/qemu/cluster.go
+++ b/platform/machine/qemu/cluster.go
@@ -76,9 +76,11 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-Environment=OUTPUT=/run/metadata/coreos
+Environment=OUTPUT=/run/metadata/flatcar
 ExecStart=/usr/bin/mkdir --parent /run/metadata
-ExecStart=/usr/bin/bash -c 'echo "COREOS_CUSTOM_PRIVATE_IPV4=`+ip+`\nCOREOS_CUSTOM_PUBLIC_IPV4=`+ip+`\n" > ${OUTPUT}'`, false)
+ExecStart=/usr/bin/bash -c 'echo "COREOS_CUSTOM_PRIVATE_IPV4=`+ip+`\nCOREOS_CUSTOM_PUBLIC_IPV4=`+ip+`\n" > ${OUTPUT}'
+ExecStartPost=/usr/bin/ln -fs /run/metadata/flatcar /run/metadata/coreos
+`, false)
 
 	var confPath string
 	if conf.IsIgnition() {


### PR DESCRIPTION
-  platform: allow CLC templating for dynamic IP address insertion
    The tests that require coreos-metadata and CLC templating could not
run because for QEMU only a static replacement was done before the
CLC configuration was rendered.
Add support for the template variables by treating QEMU as a custom
platform for the transpiler, making use of a coreos-metadata service
that has the IP addresses hardcoded.

- platform/machine/*/cluster.go: update custom coreos-metadata service
    
    The coreos-metadata service in the Flatcar OEMs normally writes to
    a "flatcar" file and symlinks it.
    Do the same for the custom ESX and QEMU coreos-metadata services.

- platform/local/dnsmasq: hardcode DNS server for QEMU tests
    
    The system may have 127.0.0.53 as DNS server which is the
    systemd-resolved stub. This is no reachable from the dnsmasq's
    network namespace which has its own loopback interface.
    Hardcode the DNS servers to Cloudflare's and Google's to ensure
    DNS is working regardless of the host /etc/resolv.conf file.

- kola/tests/*: enable more tests for QEMU

# How to use/testing done

Run QEMU tests for
```
cl.locksmith.cluster cl.etcd-member.discovery cl.etcd-member.v2-backup-restore cl.etcd-member.etcdctlv3 cl.flannel.vxlan cl.flannel.udp coreos.ignition.security.tls
```
