### PR TITLE
remove rkt and kubelet-wrapper from kubernetes tests

### DIFF
--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -52,7 +52,7 @@ func init() {
 				Name:        "google.kubernetes.basic." + r + "." + t,
 				Run:         f,
 				ClusterSize: 0,
-				Platforms:   []string{"gce", "do", "aws"}, // TODO: fix packet, esx
+				Platforms:   []string{"gce", "do", "aws", "qemu"}, // TODO: fix packet, esx
 				Distros:     []string{"cl"},
 			})
 		}

--- a/kola/tests/kubernetes/controllerInstall.go
+++ b/kola/tests/kubernetes/controllerInstall.go
@@ -36,7 +36,7 @@ export DNS_SERVICE_IP=192.168.128.10
 # Whether to use Calico for Kubernetes network policy.
 export USE_CALICO=false
 
-# Determines the container runtime for kubernetes to use. Accepts 'docker' or 'rkt'.
+# Determines the container runtime for kubernetes to use. Accepts 'docker'.
 export CONTAINER_RUNTIME={{.CONTAINER_RUNTIME}}
 
 # The above settings can optionally be overridden using an environment file:
@@ -92,10 +92,6 @@ function init_templates {
     if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
-        RKT_FLAGS=""
-        if [[ ${CONTAINER_RUNTIME} = "rkt" ]]; then
-            RKT_FLAGS="--rkt-path=/usr/bin/rkt --rkt-stage1-image=coreos.com/rkt/stage1-coreos "
-        fi
         KUBE_EXEC=""
         if [[ $K8S_VER > "v1.18" ]]; then
             KUBE_EXEC="kubelet"
@@ -104,15 +100,6 @@ function init_templates {
 [Service]
 Environment=KUBELET_IMAGE_TAG=${K8S_VER}
 Environment=KUBELET_IMAGE_URL=docker://${HYPERKUBE_IMAGE_REPO}
-Environment="RKT_RUN_ARGS=--volume dns,kind=host,source=/etc/resolv.conf \
-  --mount volume=dns,target=/etc/resolv.conf \
-  --volume=rkt,kind=host,source=/opt/bin/host-rkt \
-  --mount volume=rkt,target=/usr/bin/rkt \
-  --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
-  --mount volume=var-lib-rkt,target=/var/lib/rkt \
-  --volume=stage,kind=host,source=/tmp \
-  --mount volume=stage,target=/tmp \
-  --insecure-options=image"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStart=/usr/lib/flatcar/kubelet-wrapper ${KUBE_EXEC} \
   --register-schedulable=false \
@@ -120,7 +107,6 @@ ExecStart=/usr/lib/flatcar/kubelet-wrapper ${KUBE_EXEC} \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
   --container-runtime=${CONTAINER_RUNTIME} \
-  ${RKT_FLAGS} \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --hostname-override=${ADVERTISE_IP}
 Restart=always
@@ -153,65 +139,6 @@ contexts:
     user: kubelet
   name: kubelet-context
 current-context: kubelet-context
-EOF
-    fi
-
-    local TEMPLATE=/opt/bin/host-rkt
-    if [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-#!/bin/sh
-# This is bind mounted into the kubelet rootfs and all rkt shell-outs go
-# through this rkt wrapper. It essentially enters the host mount namespace
-# (which it is already in) only for the purpose of breaking out of the chroot
-# before calling rkt. It makes things like rkt gc work and avoids bind mounting
-# in certain rkt filesystem dependancies into the kubelet rootfs. This can
-# eventually be obviated when the write-api stuff gets upstream and rkt gc is
-# through the api-server. Related issue:
-# https://github.com/coreos/rkt/issues/2878
-exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "\$@"
-EOF
-    fi
-
-
-    local TEMPLATE=/etc/systemd/system/load-rkt-stage1.service
-    if [ ${CONTAINER_RUNTIME} = "rkt" ] && [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-[Unit]
-Description=Load rkt stage1 images
-Documentation=http://github.com/coreos/rkt
-Requires=network-online.target
-After=network-online.target
-Before=rkt-api.service
-
-[Service]
-RemainAfterExit=yes
-Type=oneshot
-ExecStart=/usr/bin/rkt fetch /usr/lib/rkt/stage1-images/stage1-coreos.aci /usr/lib/rkt/stage1-images/stage1-fly.aci  --insecure-options=image
-
-[Install]
-RequiredBy=rkt-api.service
-EOF
-    fi
-
-    local TEMPLATE=/etc/systemd/system/rkt-api.service
-    if [ ${CONTAINER_RUNTIME} = "rkt" ] && [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-[Unit]
-Before=kubelet.service
-
-[Service]
-ExecStart=/usr/bin/rkt api-service
-Restart=always
-RestartSec=10
-
-[Install]
-RequiredBy=kubelet.service
 EOF
     fi
 
@@ -262,8 +189,6 @@ kind: Pod
 metadata:
   name: kube-proxy
   namespace: kube-system
-  annotations:
-    rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
 spec:
   hostNetwork: true
   containers:
@@ -997,18 +922,11 @@ function enable_calico_policy {
 init_config
 init_templates
 
-chmod +x /opt/bin/host-rkt
-
 init_flannel
 
 systemctl stop update-engine; systemctl mask update-engine
 
 systemctl daemon-reload
-
-if [ $CONTAINER_RUNTIME = "rkt" ]; then
-        systemctl enable load-rkt-stage1
-        systemctl enable rkt-api
-fi
 
 systemctl enable flanneld; systemctl start flanneld
 systemctl enable kubelet; systemctl start kubelet

--- a/kola/tests/kubernetes/controllerInstall.go
+++ b/kola/tests/kubernetes/controllerInstall.go
@@ -515,31 +515,6 @@ EOF
                 "protocol": "TCP"
               }
             ]
-          },
-          {
-            "args": [
-              "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
-              "-port=8080",
-              "-quiet"
-            ],
-            "image": "gcr.io/google_containers/exechealthz-amd64:1.0",
-            "name": "healthz",
-            "ports": [
-              {
-                "containerPort": 8080,
-                "protocol": "TCP"
-              }
-            ],
-            "resources": {
-              "limits": {
-                "cpu": "10m",
-                "memory": "20Mi"
-              },
-              "requests": {
-                "cpu": "10m",
-                "memory": "20Mi"
-              }
-            }
           }
         ],
         "dnsPolicy": "Default"

--- a/kola/tests/kubernetes/setup.go
+++ b/kola/tests/kubernetes/setup.go
@@ -268,8 +268,6 @@ func stripSemverSuffix(v string) (string, error) {
 
 // Run and configure the coreos-kubernetes generic install scripts.
 func runInstallScript(c cluster.TestCluster, m platform.Machine, script string, options map[string]string) {
-	c.MustSSH(m, "sudo stat /usr/lib/flatcar/kubelet-wrapper")
-
 	var buffer = new(bytes.Buffer)
 
 	tmpl, err := template.New("installScript").Parse(script)

--- a/kola/tests/kubernetes/workerInstall.go
+++ b/kola/tests/kubernetes/workerInstall.go
@@ -25,7 +25,7 @@ export DNS_SERVICE_IP=192.168.128.10
 # Whether to use Calico for Kubernetes network policy.
 export USE_CALICO=false
 
-# Determines the container runtime for kubernetes to use. Accepts 'docker' or 'rkt'.
+# Determines the container runtime for kubernetes to use. Accepts 'docker'.
 export CONTAINER_RUNTIME={{.CONTAINER_RUNTIME}}
 
 # The above settings can optionally be overridden using an environment file:
@@ -58,10 +58,6 @@ function init_templates {
     if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
-        RKT_FLAGS=""
-        if [[ ${CONTAINER_RUNTIME} = "rkt" ]]; then
-            RKT_FLAGS="--rkt-path=/usr/bin/rkt --rkt-stage1-image=coreos.com/rkt/stage1-coreos "
-        fi
         KUBE_EXEC=""
         if [[ $K8S_VER > "v1.18" ]]; then
             KUBE_EXEC="kubelet"
@@ -70,21 +66,11 @@ function init_templates {
 [Service]
 Environment=KUBELET_IMAGE_TAG=${K8S_VER}
 Environment=KUBELET_IMAGE_URL=docker://${HYPERKUBE_IMAGE_REPO}
-Environment="RKT_RUN_ARGS=--volume dns,kind=host,source=/etc/resolv.conf \
-  --mount volume=dns,target=/etc/resolv.conf \
-  --volume=rkt,kind=host,source=/opt/bin/host-rkt \
-  --mount volume=rkt,target=/usr/bin/rkt \
-  --volume var-lib-rkt,kind=host,source=/var/lib/rkt \
-  --mount volume=var-lib-rkt,target=/var/lib/rkt \
-  --volume=stage,kind=host,source=/tmp \
-  --mount volume=stage,target=/tmp \
-  --insecure-options=image"
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStart=/usr/lib/flatcar/kubelet-wrapper ${KUBE_EXEC} \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
   --container-runtime=${CONTAINER_RUNTIME} \
-  ${RKT_FLAGS} \
   --register-node=true \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --hostname-override=${ADVERTISE_IP} \
@@ -98,64 +84,6 @@ MemoryAccounting=true
 
 [Install]
 WantedBy=multi-user.target
-EOF
-    fi
-
-    local TEMPLATE=/opt/bin/host-rkt
-    if [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-#!/bin/sh
-# This is bind mounted into the kubelet rootfs and all rkt shell-outs go
-# through this rkt wrapper. It essentially enters the host mount namespace
-# (which it is already in) only for the purpose of breaking out of the chroot
-# before calling rkt. It makes things like rkt gc work and avoids bind mounting
-# in certain rkt filesystem dependancies into the kubelet rootfs. This can
-# eventually be obviated when the write-api stuff gets upstream and rkt gc is
-# through the api-server. Related issue:
-# https://github.com/coreos/rkt/issues/2878
-exec nsenter -m -u -i -n -p -t 1 -- /usr/bin/rkt "\$@"
-EOF
-    fi
-
-    local TEMPLATE=/etc/systemd/system/load-rkt-stage1.service
-    if [ ${CONTAINER_RUNTIME} = "rkt" ] && [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-[Unit]
-Description=Load rkt stage1 images
-Documentation=http://github.com/coreos/rkt
-Requires=network-online.target
-After=network-online.target
-Before=rkt-api.service
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=/usr/bin/rkt fetch /usr/lib/rkt/stage1-images/stage1-coreos.aci /usr/lib/rkt/stage1-images/stage1-fly.aci  --insecure-options=image
-
-[Install]
-RequiredBy=rkt-api.service
-EOF
-    fi
-
-    local TEMPLATE=/etc/systemd/system/rkt-api.service
-    if [ ${CONTAINER_RUNTIME} = "rkt" ] && [ ! -f $TEMPLATE ]; then
-        echo "TEMPLATE: $TEMPLATE"
-        mkdir -p $(dirname $TEMPLATE)
-        cat << EOF > $TEMPLATE
-[Unit]
-Before=kubelet.service
-
-[Service]
-ExecStart=/usr/bin/rkt api-service
-Restart=always
-RestartSec=10
-
-[Install]
-RequiredBy=kubelet.service
 EOF
     fi
 
@@ -234,8 +162,6 @@ kind: Pod
 metadata:
   name: kube-proxy
   namespace: kube-system
-  annotations:
-    rkt.alpha.kubernetes.io/stage1-name-override: coreos.com/rkt/stage1-fly
 spec:
   hostNetwork: true
   containers:
@@ -353,16 +279,9 @@ EOF
 init_config
 init_templates
 
-chmod +x /opt/bin/host-rkt
-
 systemctl stop update-engine; systemctl mask update-engine
 
 systemctl daemon-reload
-
-if [ $CONTAINER_RUNTIME = "rkt" ]; then
-        systemctl enable load-rkt-stage1
-        systemctl enable rkt-api
-fi
 
 systemctl enable flanneld; systemctl start flanneld
 systemctl enable kubelet; systemctl start kubelet

--- a/kola/tests/kubernetes/workerInstall.go
+++ b/kola/tests/kubernetes/workerInstall.go
@@ -2,7 +2,11 @@ package kubernetes
 
 // https://github.com/coreos/coreos-kubernetes/tree/master/multi-node/generic.
 const workerInstallScript = `#!/bin/bash
-set -e
+export CNI_VERSION="v0.9.1"
+
+# Download dir used to store the kubernetes
+# related components
+export DOWNLOAD_DIR=/opt/bin
 
 # List of etcd servers (http://ip:port), comma separated
 export ETCD_ENDPOINTS={{.ETCD_ENDPOINTS}}
@@ -58,16 +62,13 @@ function init_templates {
     if [ ! -f $TEMPLATE ]; then
         echo "TEMPLATE: $TEMPLATE"
         mkdir -p $(dirname $TEMPLATE)
-        KUBE_EXEC=""
-        if [[ $K8S_VER > "v1.18" ]]; then
-            KUBE_EXEC="kubelet"
-        fi
         cat << EOF > $TEMPLATE
 [Service]
-Environment=KUBELET_IMAGE_TAG=${K8S_VER}
-Environment=KUBELET_IMAGE_URL=docker://${HYPERKUBE_IMAGE_REPO}
+Requires=docker.service
+After=docker.service
+ExecStartPre=/usr/bin/docker pull ${HYPERKUBE_IMAGE_REPO}:${K8S_VER}
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
-ExecStart=/usr/lib/flatcar/kubelet-wrapper ${KUBE_EXEC} \
+ExecStart=/opt/bin/kubelet \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --network-plugin=cni \
   --container-runtime=${CONTAINER_RUNTIME} \
@@ -76,7 +77,8 @@ ExecStart=/usr/lib/flatcar/kubelet-wrapper ${KUBE_EXEC} \
   --hostname-override=${ADVERTISE_IP} \
   --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
   --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
-  --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
+  --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
+  --volume-plugin-dir=/opt/libexec/kubernetes/kubelet-plugins/volume/exec/
 Restart=always
 RestartSec=10
 CPUAccounting=true
@@ -276,6 +278,13 @@ EOF
 
 }
 
+mkdir --parent /opt/cni/bin
+curl -sSL --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${K8S_VER}/bin/linux/amd64/kubelet
+curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+
+chmod +x kubelet
+mv kubelet $DOWNLOAD_DIR/
+
 init_config
 init_templates
 
@@ -283,8 +292,8 @@ systemctl stop update-engine; systemctl mask update-engine
 
 systemctl daemon-reload
 
-systemctl enable flanneld; systemctl start flanneld
-systemctl enable kubelet; systemctl start kubelet
+systemctl enable --now flanneld
+systemctl enable --now kubelet
 
 if [ $USE_CALICO = "true" ]; then
         systemctl enable calico-node; systemctl start calico-node

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -244,7 +244,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-x86_64",
 			"-machine", "accel=kvm",
 			"-cpu", "host",
-			"-m", "2048",
+			"-m", "2512",
 		}
 	case "amd64--arm64-usr":
 		qmBinary = "qemu-system-aarch64"
@@ -260,7 +260,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-x86_64",
 			"-machine", "pc-q35-2.8",
 			"-cpu", "kvm64",
-			"-m", "2048",
+			"-m", "2512",
 		}
 	case "arm64--arm64-usr":
 		qmBinary = "qemu-system-aarch64"


### PR DESCRIPTION
in this PR, we remove the usage of `rkt` runtime and the `kubelet-wrapper` in order to prepare the removal of this components from the OS.

# Testing done

It could run on `QEMU` but I have some memory issues. Tests have been done on `GCP` using `alpha-2823.0.0`: 

```
./bin/kola run --basename=${BASENAME} \
    --gce-image=${IMAGE_NAME} \
    --gce-json-key=${GCE_JSON_KEY} \
    --parallel=4 --platform=gce \
    -d -k --remove=false \
    ${TEST_NAME}
2021-04-22T12:30:43Z cli: Started logging at level DEBUG
=== RUN   google.kubernetes.basic.docker.v1.18.0
2021-04-22T12:30:43Z kola/tests/kubernetes: Creating single-node etcd
2021-04-22T12:30:43Z platform/api/gcloud: Creating instance "tormath1-tests-rkt-68160e03b7993c51b9a5"
2021-04-22T12:31:05Z platform/api/gcloud: Created instance "tormath1-tests-rkt-68160e03b7993c51b9a5"
2021-04-22T12:31:56Z kola/tests/etcd: cluster healthy
2021-04-22T12:31:56Z kola/tests/kubernetes: Creating master node
2021-04-22T12:31:56Z platform/api/gcloud: Creating instance "tormath1-tests-rkt-b05d2e43908d6d471a3c"
2021-04-22T12:32:19Z platform/api/gcloud: Created instance "tormath1-tests-rkt-b05d2e43908d6d471a3c"
2021-04-22T12:32:54Z kola/tests/kubernetes: Generating TLS assets on the master
2021-04-22T12:33:24Z kola/tests/kubernetes: Creating worker nodes
2021-04-22T12:33:24Z platform/api/gcloud: Creating instance "tormath1-tests-rkt-c1a62bcae178faafba56"
2021-04-22T12:33:37Z platform/api/gcloud: Created instance "tormath1-tests-rkt-c1a62bcae178faafba56"
2021-04-22T12:34:17Z kola/tests/kubernetes: Generating TLS assets on the workers
2021-04-22T12:34:45Z kola/tests/kubernetes: Configuring nodes by running the install scripts
2021-04-22T12:36:00Z kola/tests/kubernetes: Configuring kubectl on the master
2021-04-22T12:36:10Z kola/tests/kubernetes: Waiting for all nodes to appear on kubectl
--- PASS: google.kubernetes.basic.docker.v1.18.0 (400.16s)
```
