### PR TITLE
kola/tests/rkt: remove the rkt test from running on Alpha

### DIFF
--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -51,10 +51,11 @@ func init() {
 	})
 
 	register.Register(&register.Test{
-		Name:        "rkt.base",
-		ClusterSize: 1,
-		Run:         rktBase,
-		Distros:     []string{"cl"},
+		Name:            "rkt.base",
+		ClusterSize:     1,
+		Run:             rktBase,
+		Distros:         []string{"cl"},
+		ExcludeChannels: []string{"alpha"},
 	})
 
 }


### PR DESCRIPTION
When rkt is dropped from the Alpha image, the test will fail.
It can be kept for the other channels as long as they have rkt.
