### PR TITLE
kola/kubeadm: exclude esx from tested platforms

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -65,9 +65,10 @@ systemd:
 
 func init() {
 	register.Register(&register.Test{
-		Name:    "kubeadm.base",
-		Distros: []string{"cl"},
-		Run:     kubeadmBaseTest,
+		Name:             "kubeadm.base",
+		Distros:          []string{"cl"},
+		ExcludePlatforms: []string{"esx"},
+		Run:              kubeadmBaseTest,
 	})
 }
 


### PR DESCRIPTION
kola/kubeadm: exclude esx from tested platforms

ESX tests are failing on Jenkins with this message:
```
not ok - kubeadm.base
Error: "kubeadm.go:80: unable to setup cluster: unable
to create master node: getting machine info: waiting for net
ip: Post \"https://w.x.y.z/sdk\": context deadline exceeded"
```
which seems to be an error related to the provider itself