### PR TITLE
kola/kubeadm: exclude azure platform

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -67,7 +67,7 @@ func init() {
 	register.Register(&register.Test{
 		Name:             "kubeadm.base",
 		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"esx"},
+		ExcludePlatforms: []string{"esx", "azure"},
 		Run:              kubeadmBaseTest,
 	})
 }


### PR DESCRIPTION
tests are currently failing - we exclude them to take some time to
properly identify the underlying issue.
controller node spams a lot of FlexVolume related error:
```shell
May 17 07:54:56.409708 kubelet[2807]: W0517 07:54:56.409706    2807 driver-call.go:149] FlexVolume: driver call failed: executable: /opt/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds/uds, args: [init], error: fork/exec /opt/libexec/kubernetes/kubelet-plugins/volume/exec/nodeagent~uds/uds: no such file or directory, output: ""
May 17 07:54:56.413207 kubelet[2807]: E0517 07:54:56.413152    2807 plugins.go:748] Error dynamically probing plugins: Error creating Flexvolume plugin from directory nodeagent~uds, skipping. Error: unexpected end of JSON input
```

and from the worker node:
```shell
May 17 07:57:27.018416 kubelet[1483]: E0517 07:57:27.018373    1483 server.go:204] "Failed to load kubelet config file" err="failed to load Kubelet config file /var/lib/kubelet/config.yaml, error failed to read kubelet config file \"/var/lib/kubelet/config.yaml\", error: open /var/lib/kubelet/config.yaml: no such file or directory" path="/var/lib/kubelet/config.yaml"
May 17 07:57:27.020692 systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
May 17 07:57:27.020869 systemd[1]: kubelet.service: Failed with result 'exit-code'.
```

kubelet does not find its config, which means kubeadm does not properly
join the cluster

an issue has been opened to track this: https://github.com/kinvolk/Flatcar/issues/399