### PR TITLE
kola: update containernetworking/plugins to v0.8.7

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -39,7 +39,7 @@ var (
 	// TODO: when a new version of kubernetes will be tested, it would be nice
 	// to have a map[string]Release with Release struct holding the parameter below
 	params = map[string]interface{}{
-		"CNIVersion":     "v0.8.2",
+		"CNIVersion":     "v0.8.7",
 		"CRIctlVersion":  "v1.17.0",
 		"ReleaseVersion": "v0.4.0",
 		"Release":        "v1.21.0",
@@ -48,7 +48,7 @@ var (
 		"KubeadmSum":     "0673408403a3474c868ae86109f11f9114bca7ddce204be0d169316fb3ce0edefa4b2a472ba9b8308e423e6b927d4098ac36296405570f444f39551fb1c4bbb4",
 		"KubeletSum":     "530689c0cc32ef1830f7ae26ac10995f815043d48a905141e23a34a5e61522c4ee2ff46953648c47c5592d7c2ffa40ce90469a697f36f68475b8da5abd73f9f5",
 		"CRIctlSum":      "e258f4607a89b8d44c700036e636dd42cc3e2ed27a3bb13beef736f80f64f10b7974c01259a66131d3f7b44ed0c61b1ca0ea91597c416a9c095c432de5112d44",
-		"CNISum":         "a8fd7ffce7f4f1fb00ac2e4840b7961efc3ec844c5e99035c72baa95f038b316552ce71f8a17f82c04d614da490689953a7a80008d7b9be563187673813934b5",
+		"CNISum":         "8f2cbee3b5f94d59f919054dccfe99a8e3db5473b553d91da8af4763e811138533e05df4dbeab16b3f774852b4184a7994968f5e036a3f531ad1ac4620d10ede",
 		"KubectlSum":     "9557d298146ef62ffbcf05b3591bf1ce74f345628370447a4f614b5f64e367b5bfa8e397cc4755da9ea38f1ba04c95c65c313e735550ffc3b03c197e936c3e11",
 	}
 	plog       = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/kubeadm")


### PR DESCRIPTION
Update containernetworking/plugins to v0.8.7, mainly to address [CVE-2020-10749](https://nvd.nist.gov/vuln/detail/CVE-2020-10749) .
