### PR TITLE
kubernetes and kubeadm tests: make it work on azure

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -67,7 +67,7 @@ func init() {
 	register.Register(&register.Test{
 		Name:             "kubeadm.base",
 		Distros:          []string{"cl"},
-		ExcludePlatforms: []string{"esx", "azure"},
+		ExcludePlatforms: []string{"esx"},
 		Run:              kubeadmBaseTest,
 	})
 }

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -378,7 +378,7 @@ cat << EOF > worker-config.yaml
 EOF
 
 systemctl start --quiet coreos-metadata
-ipv4=$(cat /run/metadata/flatcar | grep -v IPV6 | grep IP | grep -E '(PRIVATE|LOCAL)' | cut -d = -f 2)
+ipv4=$(cat /run/metadata/flatcar | grep -v IPV6 | grep IP | grep -E '(PRIVATE|LOCAL|DYNAMIC)' | cut -d = -f 2)
 
 kubeadm join --config worker-config.yaml --node-name "${ipv4}"`
 )

--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -52,7 +52,7 @@ func init() {
 				Name:        "google.kubernetes.basic." + r + "." + t,
 				Run:         f,
 				ClusterSize: 0,
-				Platforms:   []string{"gce", "do", "aws", "qemu"}, // TODO: fix packet, esx
+				Platforms:   []string{"gce", "do", "aws", "qemu", "azure"}, // TODO: fix packet, esx
 				Distros:     []string{"cl"},
 			})
 		}

--- a/kola/tests/kubernetes/controllerInstall.go
+++ b/kola/tests/kubernetes/controllerInstall.go
@@ -57,7 +57,7 @@ function init_config {
 
     if [ -z $ADVERTISE_IP ]; then
         systemctl start coreos-metadata
-        export ADVERTISE_IP=$(cat /run/metadata/flatcar | grep -v IPV6 | grep IP | grep -E '(PRIVATE|LOCAL)' | cut -d = -f 2)
+        export ADVERTISE_IP=$(cat /run/metadata/flatcar | grep -v IPV6 | grep IP | grep -E '(PRIVATE|LOCAL|DYNAMIC)' | cut -d = -f 2)
     fi
 
     for REQ in "${REQUIRED[@]}"; do

--- a/kola/tests/kubernetes/workerInstall.go
+++ b/kola/tests/kubernetes/workerInstall.go
@@ -46,7 +46,7 @@ function init_config {
 
     if [ -z $ADVERTISE_IP ]; then
         systemctl start coreos-metadata
-        export ADVERTISE_IP=$(cat /run/metadata/flatcar | grep -v IPV6 | grep IP | grep -E '(PRIVATE|LOCAL)' | cut -d = -f 2)
+        export ADVERTISE_IP=$(cat /run/metadata/flatcar | grep -v IPV6 | grep IP | grep -E '(PRIVATE|LOCAL|DYNAMIC)' | cut -d = -f 2)
     fi
 
     for REQ in "${REQUIRED[@]}"; do


### PR DESCRIPTION
In this PR, we try to get `kubeadm` tests working on Azure.

- issue when we fetch the IP based on `/run/metadata/flatcar`

I investigated on other potential issues but it seems OK now. I had a doubt with some hardcoded _time to live_ for the created instances but nothing in the code.

## Testing done

```
./bin/kola run --board=amd64-usr --channel=stable --platform=azure ... kubeadm.base
```
(ran twice in a row)

closes https://github.com/kinvolk/Flatcar/issues/399