### PR TITLE
platform/util: enable selinux logs for SELinux tests

### DIFF
--- a/platform/util.go
+++ b/platform/util.go
@@ -87,6 +87,13 @@ func EnableSelinux(m Machine) error {
 	if err != nil {
 		return fmt.Errorf("Unable to enable SELinux: %s: %s", err, stderr)
 	}
+
+	// remove audit rules to get SELinux AVCs in the audit logs
+	_, stderr, err = m.SSH("sudo rm -rf /etc/audit/rules.d/{80-selinux.rules,99-default.rules}; sudo systemctl restart audit-rules")
+	if err != nil {
+		return fmt.Errorf("unable to enable SELinux audit logs: %s: %s", err, stderr)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
By default, all kola tests `setenforce 1`. This change allows user to read SELinux AVC logs from kola logs - Flatcar prevents natively AVC logs gathering (https://github.com/kinvolk/coreos-overlay/blob/main/sys-process/audit/files/rules.d/80-selinux.rules)

It will ease to identify SELinux related errors.

## How to use

before
```bash
cat _kola_temp/qemu-2021-06-22-1518-657712/docker.torcx-manifest-pkgs/151167d1-5fde-4862-93bc-312debdd4814/console.txt
...
[  167.267644] IPv6: ADDRCONF(NETDEV_CHANGE): veth1cda38f: link becomes ready
[  167.269177] docker0: port 1(veth1cda38f) entered blocking state
[  167.270341] docker0: port 1(veth1cda38f) entered forwarding state
[  167.350524] docker0: port 1(veth1cda38f) entered disabled state
[  167.352651] vethfac6db4: renamed from eth0
[  167.370865] docker0: port 1(veth1cda38f) entered disabled state
[  167.373590] device veth1cda38f left promiscuous mode
```

after
```
cat _kola_temp/qemu-latest/docker.torcx-manifest-pkgs/8b6b8551-b49e-467f-bba4-00702bda9429/console.txt
[  165.151453] docker0: port 1(veth8f24c8f) entered forwarding state
[  165.197868] audit: type=1400 audit(1624369059.983:507): avc:  denied  { read } for  pid=9403 comm="sh" path="pipe:[40100]" dev="pipefs" ino=40100 scontext=system_u:system_r:svirt_lxc_net_t:s0:c98,c688 tcontext=system_u:system_r:kernel_t:s0 tclass=fifo_file permissive=0
[  165.204510] audit: type=1400 audit(1624369059.983:507): avc:  denied  { write } for  pid=9403 comm="sh" path="pipe:[40101]" dev="pipefs" ino=40101 scontext=system_u:system_r:svirt_lxc_net_t:s0:c98,c688 tcontext=system_u:system_r:kernel_t:s0 tclass=fifo_file permissive=0
[  165.273261] docker0: port 1(veth8f24c8f) entered disabled state
[  165.279903] veth880cb8f: renamed from eth0
[  165.308471] docker0: port 1(veth8f24c8f) entered disabled state
```
