### PR TITLE
kola/tests: Exclude rkt tests from alpha & beta channels

### DIFF
--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -43,11 +43,12 @@ var config = conf.Ignition(`{
 
 func init() {
 	register.Register(&register.Test{
-		Name:        "cl.rkt.etcd3",
-		Run:         rktEtcd,
-		ClusterSize: 1,
-		Distros:     []string{"cl"},
-		UserData:    config,
+		Name:            "cl.rkt.etcd3",
+		Run:             rktEtcd,
+		ClusterSize:     1,
+		Distros:         []string{"cl"},
+		UserData:        config,
+		ExcludeChannels: []string{"alpha", "beta"},
 	})
 
 	register.Register(&register.Test{
@@ -55,7 +56,7 @@ func init() {
 		ClusterSize:     1,
 		Run:             rktBase,
 		Distros:         []string{"cl"},
-		ExcludeChannels: []string{"alpha"},
+		ExcludeChannels: []string{"alpha", "beta"},
 	})
 
 }


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# kola/tests: Exclude rkt tests from alpha & beta channels

rkt has been deprecation is promoted to Beta, so the tests need to be removed.

## How to use

```
> ./bin/kola list --channel stable --filter "*rkt*"
Test Name	Platforms	Architectures	Distributions	Channels		Offerings
											
cl.rkt.etcd3	[all]		[all]		[cl]		[stable edge lts]	[all]
rkt.base	[all]		[all]		[cl]		[stable edge lts]	[all]
> ./bin/kola list --channel beta --filter "*rkt*"
Test Name	Platforms	Architectures	Distributions	ChannelsOfferings
```
