### PR TITLE
cork: fix handling of /dev/shm -> /run/shm symlinks

### DIFF
--- a/sdk/enter.go
+++ b/sdk/enter.go
@@ -142,10 +142,10 @@ func (e *enter) MountAPI() error {
 			return fmt.Errorf("Unexpected shm path: %s", shmPath)
 		}
 		newPath := filepath.Join(e.Chroot, shmPath)
-		if err := os.Mkdir(newPath, 01777); err != nil {
+		if err := os.Mkdir(newPath, 0777|os.ModeSticky); err != nil {
 			return err
 		}
-		if err := os.Chmod(newPath, 01777); err != nil {
+		if err := os.Chmod(newPath, 0777|os.ModeSticky); err != nil {
 			return err
 		}
 	} else {

--- a/system/symlink.go
+++ b/system/symlink.go
@@ -21,5 +21,5 @@ import (
 // IsSymlink checks if a path is a symbolic link.
 func IsSymlink(path string) bool {
 	st, err := os.Lstat(path)
-	return err != nil && st.Mode()&os.ModeSymlink == os.ModeSymlink
+	return err == nil && st.Mode()&os.ModeSymlink == os.ModeSymlink
 }


### PR DESCRIPTION
# cork: fix handling of /dev/shm -> /run/shm symlinks

In WSL2 /dev/shm is a symlink to /run/shm. cork has code to handle that but that code didn't work correctly and resulted in "permission denied" errors when entering the SDK chroot.

## How to use

`cork create` in a WSL2 terminal.

## Testing done

`cork create`, checked that no errors occur, and then `cork enter` and checked that /run/shm

1. exists
2. has the sticky bit set

by running `ls -ld /run/shm` in the chroot.
