### PR TITLE
platform/qemu: specify raw backing_fmt explicitly

### DIFF
--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -194,8 +194,12 @@ func setupDiskFromFile(imageFile string) (*os.File, error) {
 			return nil, err
 		}
 	}
+	imgInfo, err := util.GetImageInfo(backingFile)
+	if err != nil {
+		return nil, err
+	}
 
-	qcowOpts := fmt.Sprintf("backing_file=%s,lazy_refcounts=on", backingFile)
+	qcowOpts := fmt.Sprintf("backing_file=%s,backing_fmt=%s,lazy_refcounts=on", backingFile, imgInfo.Format)
 	return setupDisk("-o", qcowOpts)
 }
 


### PR DESCRIPTION
# Silence warnings from qemu-img

Kola output is littered with warnings about auto-detection of backing image format, this PR deals with those.

## How to use

`./build_image` + `kola run`.

## Testing done

`kola run` before and after, and verified that warnings about backing_fmt gone.