### PR TITLE
platform: provide Board access to the runtime

### DIFF
--- a/cmd/kola/options.go
+++ b/cmd/kola/options.go
@@ -170,7 +170,18 @@ func init() {
 
 // Sync up the command line options if there is dependency
 func syncOptions() error {
-	kola.PacketOptions.Board = kola.QEMUOptions.Board
+	// sync `Board` option with other cloud provider
+	// it seems kola has a strong dependency to qemu and it has been
+	// build around that's why the `Board` is associated to `QEMU`
+	// but it can be helpful for other provider to get access to the Board in the runtime
+	board := kola.QEMUOptions.Board
+	kola.OpenStackOptions.Board = board
+	kola.GCEOptions.Board = board
+	kola.ESXOptions.Board = board
+	kola.DOOptions.Board = board
+	kola.AzureOptions.Board = board
+	kola.AWSOptions.Board = board
+	kola.PacketOptions.Board = board
 	kola.PacketOptions.GSOptions = &kola.GCEOptions
 
 	validateOption := func(name, item string, valid []string) error {

--- a/cmd/ore/packet/packet.go
+++ b/cmd/ore/packet/packet.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/cli"
+	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/gcloud"
 	"github.com/coreos/mantle/platform/api/packet"
 	"github.com/coreos/pkg/capnslog"
@@ -35,7 +36,7 @@ var (
 	}
 
 	API       *packet.API
-	options   packet.Options
+	options   = packet.Options{Options: &platform.Options{}}
 	gsOptions gcloud.Options
 )
 
@@ -49,6 +50,7 @@ func init() {
 	Packet.PersistentFlags().StringVar(&options.ApiKey, "api-key", "", "API key (overrides config file)")
 	Packet.PersistentFlags().StringVar(&options.Project, "project", "", "project UUID (overrides config file)")
 	cli.WrapPreRun(Packet, preflightCheck)
+
 }
 
 func preflightCheck(cmd *cobra.Command, args []string) error {

--- a/platform/api/packet/api.go
+++ b/platform/api/packet/api.go
@@ -88,8 +88,6 @@ type Options struct {
 	Facility string
 	// Slug of the device type (e.g. "baremetal_0")
 	Plan string
-	// The Container Linux board name
-	Board string
 	// e.g. http://alpha.release.flatcar-linux.net/amd64-usr/current
 	InstallerImageBaseURL string
 	// e.g. http://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz

--- a/platform/flight.go
+++ b/platform/flight.go
@@ -108,3 +108,9 @@ func (bf *BaseFlight) Destroy() {
 		plog.Errorf("Error closing agent: %v", err)
 	}
 }
+
+// Options will return the base options for the current
+// flight
+func (bf *BaseFlight) Options() *Options {
+	return bf.baseopts
+}

--- a/platform/machine/aws/machine.go
+++ b/platform/machine/aws/machine.go
@@ -157,3 +157,7 @@ func (am *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (am *machine) Board() string {
+	return am.cluster.flight.Options().Board
+}

--- a/platform/machine/azure/machine.go
+++ b/platform/machine/azure/machine.go
@@ -140,3 +140,7 @@ func (am *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (am *machine) Board() string {
+	return am.cluster.flight.Options().Board
+}

--- a/platform/machine/do/machine.go
+++ b/platform/machine/do/machine.go
@@ -92,3 +92,7 @@ func (dm *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (dm *machine) Board() string {
+	return dm.cluster.flight.Options().Board
+}

--- a/platform/machine/esx/machine.go
+++ b/platform/machine/esx/machine.go
@@ -127,3 +127,7 @@ func (em *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (em *machine) Board() string {
+	return em.cluster.flight.Options().Board
+}

--- a/platform/machine/gcloud/machine.go
+++ b/platform/machine/gcloud/machine.go
@@ -114,3 +114,7 @@ func (gm *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (gm *machine) Board() string {
+	return gm.gc.flight.Options().Board
+}

--- a/platform/machine/openstack/machine.go
+++ b/platform/machine/openstack/machine.go
@@ -135,3 +135,7 @@ func (om *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (om *machine) Board() string {
+	return om.cluster.flight.Options().Board
+}

--- a/platform/machine/packet/machine.go
+++ b/platform/machine/packet/machine.go
@@ -108,3 +108,7 @@ func (pm *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (pm *machine) Board() string {
+	return pm.cluster.flight.Options().Board
+}

--- a/platform/machine/qemu/flight.go
+++ b/platform/machine/qemu/flight.go
@@ -34,7 +34,6 @@ const (
 type Options struct {
 	// DiskImage is the full path to the disk image to boot in QEMU.
 	DiskImage string
-	Board     string
 
 	// BIOSImage is name of the BIOS file to pass to QEMU.
 	// It can be a plain name, or a full path.

--- a/platform/machine/qemu/machine.go
+++ b/platform/machine/qemu/machine.go
@@ -97,3 +97,7 @@ func (m *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (m *machine) Board() string {
+	return m.qc.flight.Options().Board
+}

--- a/platform/machine/unprivqemu/machine.go
+++ b/platform/machine/unprivqemu/machine.go
@@ -96,3 +96,7 @@ func (m *machine) JournalOutput() string {
 	}
 	return string(data)
 }
+
+func (m *machine) Board() string {
+	return m.qc.flight.Options().Board
+}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -80,6 +80,9 @@ type Machine interface {
 	// JournalOutput returns the machine's journal output if available,
 	// or an empty string.  Only expected to be valid after Destroy().
 	JournalOutput() string
+
+	// Board returns the machine's board
+	Board() string
 }
 
 // Cluster represents a cluster of machines within a single Flight.
@@ -158,6 +161,9 @@ type Options struct {
 	// When specified additional files & units will be automatically generated
 	// inside of RenderUserData
 	OSContainer string
+
+	// Board is the board used by the image
+	Board string
 }
 
 // RuntimeConfig contains cluster-specific configuration.


### PR DESCRIPTION
`board` is accessible only for Packet and QEMU machines. It can be helpful to get this value for other machine in order to do some conditional operation in the setup - like enforcing SELinux. See: https://github.com/kinvolk/mantle/pull/180#issuecomment-875497624.

In this PR, we provide a new `Board () string` method to the `Machine` interface.

`Board()` returns value from a new base options implemented in `platform.Options`. We currently need to use the `syncoptions`  method to pass the value of the `board` to each provider - this one is provided by the `--board` flag bound to the `kola.QEMUOptions.Board`

Based on the `options.Board` we now conditionally enable SELinux on the machine.
