### PR TITLE
kola/tests/util/update: use correct command name

### DIFF
--- a/kola/tests/util/update.go
+++ b/kola/tests/util/update.go
@@ -44,7 +44,7 @@ func GetUsrDeviceNode(c cluster.TestCluster, m platform.Machine) string {
 }
 
 func InvalidateUsrPartition(c cluster.TestCluster, m platform.Machine, partition string) {
-	if out, stderr, err := m.SSH(fmt.Sprintf("sudo coreos-setgoodroot && sudo wipefs /dev/disk/by-partlabel/%s", partition)); err != nil {
+	if out, stderr, err := m.SSH(fmt.Sprintf("sudo flatcar-setgoodroot && sudo wipefs /dev/disk/by-partlabel/%s", partition)); err != nil {
 		c.Fatalf("invalidating %s failed: %s: %v: %s", partition, out, err, stderr)
 	}
 }


### PR DESCRIPTION
The switch from coreos-setgoodroot to flatcar-setgoodroot was done for
cmd/kola/updatepayload.go but not yet for kola/tests/util/update.go.
Use flatcar-setgoodroot which is the new name.


## How to use

Together with https://github.com/kinvolk/flatcar-scripts/pull/130

## Testing done

`sudo kola run …run -k -d --board=amd64-usr --platform=qemu --qemu-image=tmp/flatcar_production_qemu_image.img  --update-payload=tmp/flatcar_test_update.gz cl.update.payload`

```
--- PASS: cl.update.payload (209.74s)
        cluster.go:117: Created symlink /etc/systemd/system/locksmithd.service → /dev/null.
        update.go:149: Triggering update_engine
        update.go:168: Rebooting test machine
        update.go:149: Triggering update_engine
        update.go:168: Rebooting test machine
PASS, output in _kola_temp/qemu-2021-07-12-1957-2564530
```
