### PR TITLE
kola/docker: accept 'cgroupns' security option

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -616,7 +616,7 @@ func testDockerInfo(expectedFs string, c cluster.TestCluster) {
 func hasSecurityOptions(opts []string) bool {
 	for _, opt := range opts {
 		switch opt {
-		case "selinux", "seccomp":
+		case "selinux", "seccomp", "cgroupns":
 		default:
 			return false
 		}


### PR DESCRIPTION
# kola/docker: accept 'cgroupns' security option

Docker 20 with cgroupv2 reports "seccomp" and "cgroupns" security options. Allow both in the tests that check security options, which will work with current images and future images.