### PR TITLE
kola/tests/update: increase update timeout for arm64

### DIFF
--- a/kola/tests/update/update.go
+++ b/kola/tests/update/update.go
@@ -153,7 +153,7 @@ func updateMachine(c cluster.TestCluster, m platform.Machine) {
 		c.Fatalf("Executing update_engine_client failed: %v: %v: %s", out, err, stderr)
 	}
 
-	err = util.WaitUntilReady(120*time.Second, 10*time.Second, func() (bool, error) {
+	err = util.WaitUntilReady(600*time.Second, 10*time.Second, func() (bool, error) {
 		envs, stderr, err := m.SSH("update_engine_client -status 2>/dev/null")
 		if err != nil {
 			return false, fmt.Errorf("checking status failed: %v: %s", err, stderr)


### PR DESCRIPTION
The 2 minute timeout was too short on arm64 qemu emulation for
completing the update.
Increase the timeout to 10 minutes.

## How to use/testing done

```
sudo ./kola run --board=arm64-usr --channel=alpha --platform=qemu  --update-payload=tmp/flatcar_test_update.gz --qemu-bios=tmp/flatcar_production_qemu_uefi_efi_code.fd --qemu-image=tmp/flatcar_production_image.bin cl.update.payload
=== RUN   cl.update.payload
--- PASS: cl.update.payload (1032.33s)
        cluster.go:117: Created symlink /etc/systemd/system/locksmithd.service → /dev/null.
        update.go:149: Triggering update_engine
        update.go:168: Rebooting test machine
        update.go:149: Triggering update_engine
        update.go:168: Rebooting test machine
PASS, output in _kola_temp/qemu-2021-07-14-1931-2822851
```

