### PR TITLE
kola/tests/verity: fall back to expected dm-verity offset

### DIFF
--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -60,9 +60,8 @@ func VerityVerify(c cluster.TestCluster) {
 	// find /usr dev
 	usrdev := util.GetUsrDeviceNode(c, m)
 
-	// figure out partition size for hash dev offset
-	offset := c.MustSSH(m, "sudo e2size "+usrdev)
-	offset = bytes.TrimSpace(offset)
+	// figure out partition size for hash dev offset, fallback to the expected value in case e2size doesn't work
+	offset := c.MustSSH(m, "sudo e2size "+usrdev+" || echo 1065345024")
 
 	c.MustSSH(m, fmt.Sprintf("sudo veritysetup verify --verbose --hash-offset=%s %s %s %s", offset, usrdev, usrdev, hash))
 }


### PR DESCRIPTION
- kola/tests/verity: fall back to expected dm-verity offset
    
    When e2size can't find the size it returns an error exit code and
    stdout stays empty, failing the test. However, the hash offset is
    actually fixed because the GPT disk layout has to stay the same in
    Flatcar Container Linux as the partition contents are swapped out
    when updating. In case another filesystem like btrfs is used, e2size
    doesn't work and it makes sense to fall back to the only value which
    is supported in general.

- kola/tests/verity: skip the corruption test for btrfs
    
    The corruption test corrupts a particular file and checks that read
    syscalls for this file fail. With btrfs is is not easy to find the
    right block to corrupt. It is also currently discussed to issue a
    kernel panic on corruption because failed read syscalls still allow to
    alter the system behavior and are harder to spot in logs.
    For now, just skip the corruption test for btrfs and later we can
    update it to check that kernel panics work when any corruption is
    detected, not only a particular file.

## How to use

Run the test with the Flatcar image that has a btrfs /usr partition, built from http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3029/cldsv/ with the coreos-overlay branch `kai/bootengine-verity-hashoffset` from https://github.com/kinvolk/coreos-overlay/pull/1106 and flatcar-scripts branch `kai/btrfs-usr-oem` from https://github.com/kinvolk/flatcar-scripts/pull/131

## Testing done

`kola run … cl.verity` locally and it passed