### PR TITLE
kola/test: disable tests that won't work with docker 20.10

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/lang/worker"
@@ -76,6 +77,8 @@ func init() {
 		Name:          "docker.oldclient",
 		Architectures: []string{"amd64"},
 		Distros:       []string{"cl"},
+		// incompatible with docker >=20.10
+		EndVersion: semver.Version{Major: 2956},
 	})
 	register.Register(&register.Test{
 		Run:         dockerUserns,

--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
@@ -54,6 +55,8 @@ func init() {
 				ClusterSize: 0,
 				Platforms:   []string{"gce", "do", "aws", "qemu", "azure"}, // TODO: fix packet, esx
 				Distros:     []string{"cl"},
+				// incompatible with docker >=20.10
+				EndVersion: semver.Version{Major: 2956},
 			})
 		}
 	}


### PR DESCRIPTION
# Disable old tests for alpha channel

docker 1.9 and kubernetes <1.19 are not compatible with docker 20 that we are rolling into alpha. These tests need to be excluded, to be removed later.

## How to use

Fetch the image from http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3035/ and run test (`kola run`)

## Testing done

`kola run`

See also kinvolk/coreos-overlay#931