### PR TITLE
kola/test/update: reconfigure the instance once rebooted

### DIFF
--- a/kola/tests/update/update.go
+++ b/kola/tests/update/update.go
@@ -83,6 +83,16 @@ func payload(c cluster.TestCluster) {
 
 	tutil.InvalidateUsrPartition(c, m, "USR-A")
 
+	/*
+		in the case we previously downloaded and installed an **official** release, the
+		/usr/share/update_engine/update-payload-key.pub.pem will be changed to the official one.
+		In consequence, update-engine will fail to verify the update payload since this
+		one appears to be signed, in a test context, with a dev-key (generated from
+		the SDK.)
+		We configure again to inject the dev-pub-key to correctly verify the downloaded payload
+	*/
+	configureMachineForUpdate(c, m, addr)
+
 	updateMachine(c, m)
 
 	tutil.AssertBootedUsr(c, m, "USR-A")


### PR DESCRIPTION
the instance is currently configured once to be able to use
the `update_payload`.
Once the payload downloaded and the instance rebooted, kola
is going to download again an update: in the case we previously
downloaded and installed an official release, the
/usr/share/update-engine/pub-key will be changed to the official one.
So update-engine will fail to verify the new update payload since this
one appears to be signed only with a dev-key (it's generated from
the SDK.)
So we reconfigure again to inject the dev-pub-key to verify correctly
the downloaded payload

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>
