### PR TITLE
kola/tests/rkt: exclude `stable` channel

### DIFF
--- a/kola/tests/rkt/rkt.go
+++ b/kola/tests/rkt/rkt.go
@@ -48,7 +48,7 @@ func init() {
 		ClusterSize:     1,
 		Distros:         []string{"cl"},
 		UserData:        config,
-		ExcludeChannels: []string{"alpha", "beta"},
+		ExcludeChannels: []string{"alpha", "beta", "stable"},
 	})
 
 	register.Register(&register.Test{
@@ -56,7 +56,7 @@ func init() {
 		ClusterSize:     1,
 		Run:             rktBase,
 		Distros:         []string{"cl"},
-		ExcludeChannels: []string{"alpha", "beta"},
+		ExcludeChannels: []string{"alpha", "beta", "stable"},
 	})
 
 }


### PR DESCRIPTION
`rkt` won't be present in the next `stable` release, we can safely exclude rkt tests
from this channel

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>