### PR TITLE
kola/tests/docker: exclude `stable` from torcx

### DIFF
--- a/kola/tests/docker/torcx_docker_flag.go
+++ b/kola/tests/docker/torcx_docker_flag.go
@@ -38,7 +38,7 @@ storage:
       mode: 0644
 `),
 		Distros:         []string{"cl"},
-		ExcludeChannels: []string{"alpha", "beta", "edge"},
+		ExcludeChannels: []string{"alpha", "beta", "edge", "stable"},
 	})
 	register.Register(&register.Test{
 		Run:         dockerTorcxFlagFileCloudConfig,
@@ -52,7 +52,7 @@ write_files:
 `),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
-		ExcludeChannels:  []string{"alpha", "beta", "edge"},
+		ExcludeChannels:  []string{"alpha", "beta", "edge", "stable"},
 	})
 }
 


### PR DESCRIPTION
docker 1.12 is not shipped anymore on next `stable`.
See: https://github.com/kinvolk/coreos-overlay/commit/787353d775a103b3d3017aa12f02635636a30070

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>


(sorry for the spam I could have group this with the previous PR) 