### PR TITLE
kola/kubeadm: add kubernetes 1.22 test

### DIFF
--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -261,12 +261,22 @@ curl --retry-delay 1 \
     -sSL \
     "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" |
     sed "s:/usr/bin:${DOWNLOAD_DIR}:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-    
+
+
+# we get the node cgroup driver
+# in order to pass the params to the
+# kubelet config for both controller and worker
+cgroup=$(docker info | awk '/Cgroup Driver/ { print $3}')
+
 # we create the kubeadm config
 # plugin-volume-dir and flex-volume-plugin-dir are required since /usr is read-only mounted
 # etcd is also defined as external. The provided one has some issues with docker and selinux
 # (permission denied with /var/lib/etcd) so it can't boot properly
 cat << EOF > kubeadm-config.yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: ${cgroup}
+---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 nodeRegistration:
@@ -356,6 +366,10 @@ controlPlane:
 nodeRegistration:
   kubeletExtraArgs:
     volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: ${cgroup}
 EOF
 `
 

--- a/kola/tests/kubeadm/testdata/master-calico-script.sh
+++ b/kola/tests/kubeadm/testdata/master-calico-script.sh
@@ -33,12 +33,22 @@ curl --retry-delay 1 \
     -sSL \
     "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" |
     sed "s:/usr/bin:${DOWNLOAD_DIR}:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-    
+
+
+# we get the node cgroup driver
+# in order to pass the params to the
+# kubelet config for both controller and worker
+cgroup=$(docker info | awk '/Cgroup Driver/ { print $3}')
+
 # we create the kubeadm config
 # plugin-volume-dir and flex-volume-plugin-dir are required since /usr is read-only mounted
 # etcd is also defined as external. The provided one has some issues with docker and selinux
 # (permission denied with /var/lib/etcd) so it can't boot properly
 cat << EOF > kubeadm-config.yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: ${cgroup}
+---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 nodeRegistration:
@@ -117,4 +127,8 @@ controlPlane:
 nodeRegistration:
   kubeletExtraArgs:
     volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: ${cgroup}
 EOF

--- a/kola/tests/kubeadm/testdata/master-cilium-script.sh
+++ b/kola/tests/kubeadm/testdata/master-cilium-script.sh
@@ -33,12 +33,22 @@ curl --retry-delay 1 \
     -sSL \
     "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" |
     sed "s:/usr/bin:${DOWNLOAD_DIR}:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-    
+
+
+# we get the node cgroup driver
+# in order to pass the params to the
+# kubelet config for both controller and worker
+cgroup=$(docker info | awk '/Cgroup Driver/ { print $3}')
+
 # we create the kubeadm config
 # plugin-volume-dir and flex-volume-plugin-dir are required since /usr is read-only mounted
 # etcd is also defined as external. The provided one has some issues with docker and selinux
 # (permission denied with /var/lib/etcd) so it can't boot properly
 cat << EOF > kubeadm-config.yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: ${cgroup}
+---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 nodeRegistration:
@@ -102,4 +112,8 @@ controlPlane:
 nodeRegistration:
   kubeletExtraArgs:
     volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: ${cgroup}
 EOF


### PR DESCRIPTION
this commit brings a new release of kubernetes to test but it also fixes
a `TODO:`. We are now able to provide multiple kubernetes release to
test.
We just need to create a new `map[string]interface{}` holding the
params of the kubernetes release we want to test.

```
$ ./bin/kola list
kubeadm.v1.21.0.calico.base
kubeadm.v1.21.0.cilium.base
kubeadm.v1.21.0.flannel.base
kubeadm.v1.22.0.calico.base
kubeadm.v1.22.0.cilium.base
kubeadm.v1.22.0.flannel.base
```

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

**note for reviewers**:
* I'm a bit concerned by the number of tests we provide now for kubernetes: versions + CNIs are creating big test matrix which can slow down the tests overall... but I guess it's the price to pay in order to identify potential failures with kubernetes workloads
