### PR TITLE
Expect kernel panic when dm-verity detects corruption

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -91,8 +91,9 @@ var (
 			skipFlag: &[]register.Flag{register.NoEmergencyShellCheck}[0],
 		},
 		{
-			desc:  "kernel panic",
-			match: regexp.MustCompile("Kernel panic - not syncing: (.*)"),
+			desc:     "kernel panic",
+			match:    regexp.MustCompile("Kernel panic - not syncing: (.*)"),
+			skipFlag: &[]register.Flag{register.NoKernelPanicCheck}[0],
 		},
 		{
 			desc:  "kernel oops",

--- a/kola/register/register.go
+++ b/kola/register/register.go
@@ -31,6 +31,7 @@ const (
 	NoSSHKeyInMetadata                // don't add SSH key to platform metadata
 	NoEmergencyShellCheck             // don't check console output for emergency shell invocation
 	NoEnableSelinux                   // don't enable selinux when starting or rebooting a machine
+	NoKernelPanicCheck                // don't check console output for kernel panic
 )
 
 // Test provides the main test abstraction for kola. The run function is

--- a/kola/tests/misc/update.go
+++ b/kola/tests/misc/update.go
@@ -51,7 +51,7 @@ func init() {
 		Run:         RecoverBadVerity,
 		ClusterSize: 1,
 		Name:        "cl.update.badverity",
-		Flags:       []register.Flag{register.NoEmergencyShellCheck},
+		Flags:       []register.Flag{register.NoEmergencyShellCheck, register.NoKernelPanicCheck},
 		UserData:    disableUpdateEngine,
 		Distros:     []string{"cl"},
 	})
@@ -106,6 +106,7 @@ func RecoverBadVerity(c cluster.TestCluster) {
 	c.MustSSH(m, fmt.Sprintf("sudo dd of=/boot/flatcar/vmlinuz-b bs=1 seek=%d count=64 conv=notrunc status=none <<<0000000000000000000000000000000000000000000000000000000000000000", getKernelVerityHashOffset(c)))
 
 	prioritizeUsr(c, m, "USR-B")
+	// rebootWithEmergencyShellTimeout also covers the kernel panic timeout of 1 minute before reboot
 	rebootWithEmergencyShellTimeout(c, m)
 	util.AssertBootedUsr(c, m, "USR-A")
 }


### PR DESCRIPTION
The dm-verity behavior was to only let some syscalls fail but it let
the system run in a broken state. By enabling kernel panics on
corruption detection we get a more reasonable behavior. This change is
done in https://github.com/kinvolk/bootengine/pull/26
To support the new behavior the test that do corrupt on purpose need to
be flagged to be excluded from the kernel panic checks. The corruption
test also shouldn't test for a failed syscall anymore but expect the
kernel panic to render the machine unreachable.

Implement the test flag to ignore kernel panics on the console and
modify the corruption test to fit the new behavior, which also makes
the test easier because it doesn't need to find the exact file to
corrupt and we can destroy the filesystem metadata and then try to read
any file.
Since there is currently no way to specify which release version a test
requires, all channels have to be skipped for now until shortly before
the release of each channel is built.


## How to use/testing done

To test that the [image built with dm-verity kernel panics](https://storage.googleapis.com/flatcar-jenkins/developer/developer/boards/amd64-usr/2021.07.28+dev-flatcar-master-3152/flatcar_production_image.bin.bz2) works, pass `--channel=edge` as this channel is allowed to run the new test.

*Note:* Before releasing the new Alpha, remove `"alpha"` from the excluded tests.