### PR TITLE
kola: support nightly version in version comparisons

### DIFF
--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
@@ -29,12 +30,12 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:             Verity,
-		ClusterSize:     1,
-		Name:            "cl.verity",
-		Distros:         []string{"cl"},
-		Flags:           []register.Flag{register.NoKernelPanicCheck},
-		ExcludeChannels: []string{"beta", "stable"}, // can only be enabled for each channel immediately before the release
+		Run:         Verity,
+		ClusterSize: 1,
+		Name:        "cl.verity",
+		Distros:     []string{"cl"},
+		Flags:       []register.Flag{register.NoKernelPanicCheck},
+		MinVersion:  semver.Version{Major: 2943},
 	})
 }
 


### PR DESCRIPTION
- kola: support nightly version in version comparions
    
    The nightly version is the build date but the build ID has the branch
    reference. To support the version comparion for nightly builds we need
    to generate a version for the "main" branch and the major version
    branches that is higher than the current release version.
    
    Use 999999.99.99 as version in the semantic version checks for nightly
    builds from the "main" branch or custom dev builds and use MAJOR.99.99
    as version for nightly builds from the release branch.
- kola/tests/misc/verity: run test based on major version

## How to use


## Testing done

```
$ sudo ./kola run  -k --keys --key ~/.ssh/id_rsa.pub --board=amd64-usr --channel=alpha --parallel=1 --platform=qemu    --qemu-image=flatcar_production_image.bin
2021-08-02T15:25:15Z kola: Using "999999.99.99" as version to filter tests...
=== RUN   cl.network.initramfs.second-boot
[…]
```