### PR TITLE
kola: support lts version in version comparisons

### DIFF
--- a/kola/harness.go
+++ b/kola/harness.go
@@ -447,7 +447,11 @@ func getClusterSemver(flight platform.Flight, outputDir string) (*semver.Version
 		ver = "999999.99.99"
 	} else if strings.HasPrefix(branch, "flatcar-") {
 		// flatcar-MAJOR is a nightly build of the release branch
-		major := strings.Split(branch, "-")[1]
+		branchparts := strings.Split(branch, "-")
+		major := branchparts[1]
+		if major == "lts" {
+			major = branchparts[2]
+		}
 		ver = major + ".99.99"
 	}
 	plog.Noticef("Using %q as version to filter tests...", ver)


### PR DESCRIPTION
# kola: support lts version in version comparisons

This fixes a small issue in how the lts version number is parsed after the introduction of nightly version number parsing.
