### PR TITLE
kola/tests/misc/verity: add recursive list to provoke panic

### DIFF
--- a/kola/tests/misc/verity.go
+++ b/kola/tests/misc/verity.go
@@ -97,8 +97,9 @@ func VerityCorruption(c cluster.TestCluster) {
 	c.MustSSH(m, fmt.Sprintf(`sudo dd if=/dev/zero of=%s bs=1M count=10 status=none`, usrdev))
 
 	// make sure we flush everything so the filesystem has to go through to the device backing verity before fetching a file from /usr
-	// (done in one execution because after flushing command itself runs the corruption could already be detected).
-	_, err := c.SSH(m, "sudo /bin/sh -c 'sync; echo -n 3 >/proc/sys/vm/drop_caches; cat /usr/lib/os-release'")
+	// (done in one execution because after flushing command itself runs the corruption could already be detected,
+	// we just need to give arm64 QEMU tests a few more chances to detect the corruption while one 'cat' execution is enough on amd64).
+	_, err := c.SSH(m, "sudo /bin/sh -c 'sync; echo -n 3 >/proc/sys/vm/drop_caches; cat /usr/lib/os-release; ls -R /usr'")
 	if err == nil {
 		c.Fatalf("verity did not prevent reading from a corrupted disk (expected kernel panic)!")
 	}


### PR DESCRIPTION
On amd64 the panic was triggered by the 'cat' execution as expected
but on arm64 through QEMU emulation the kernel panic took a while to
be triggered. It seems the most reliable way is to walk the filesystem.

Add a recursive list to provoke the panic on arm64 if it didn't get
triggered by the simple 'cat' file reading.

## How to use/Testing done

`sudo ./kola run -d -k --keys --key ~/.ssh/id_rsa.pub --board=arm64-usr --channel=alpha --parallel=1 --platform=qemu    --qemu-image=flatcar_production_image.bin   --qemu-bios=…/flatcar_production_qemu_uefi_efi_code.fd cl.verity`