### PR TITLE
build: remove deprecated flags

### DIFF
--- a/build
+++ b/build
@@ -17,7 +17,7 @@ ldflags="-X ${REPO_PATH}/version.Version=${version}"
 
 host_build() {
 	echo "Building $1"
-	go build -i \
+	go build \
 		-ldflags "${ldflags}" \
 		-mod vendor \
 		-o "bin/$1" \


### PR DESCRIPTION
The `-i` flag is deprecated for `go build` in newer compiler versions

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>
