### PR TITLE
kola/kubeadm: fix CNI selection

### DIFF
--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -76,12 +76,17 @@ systemd:
 
 func init() {
 	for _, CNI := range CNIs {
+		// we need to copy the value of `CNI` to pass it
+		// to the `Run` method, otherwise only the last
+		// value of `CNI` (`cilium`) will be used in the registered
+		// test
+		cni := CNI
 		register.Register(&register.Test{
-			Name:             fmt.Sprintf("kubeadm.%s.base", CNI),
+			Name:             fmt.Sprintf("kubeadm.%s.base", cni),
 			Distros:          []string{"cl"},
 			ExcludePlatforms: []string{"esx"},
 			Run: func(c cluster.TestCluster) {
-				kubeadmBaseTest(c, CNI)
+				kubeadmBaseTest(c, cni)
 			},
 		})
 	}


### PR DESCRIPTION
register action was keeping the latest occurence of `CNI` so it was
basically always testing the `cilium` CNI.

... it happens.

The issue was already being fixed into #196 but it's better to be merged now to confirm that https://github.com/kinvolk/coreos-overlay/pull/1181 is solving the actual `flannel` issue raised in https://github.com/kinvolk/mantle/pull/196#issuecomment-895358491
