### PR TITLE
sdk: pass '--quiet' to repo sync

### DIFF
--- a/cmd/cork/create.go
+++ b/cmd/cork/create.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/coreos/pkg/capnslog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -282,7 +283,8 @@ func updateRepo() {
 		}
 	}
 
-	if err := sdk.RepoSync(chrootName, forceSync, useHostDNS); err != nil {
+	verbose := plog.LevelAt(capnslog.INFO)
+	if err := sdk.RepoSync(chrootName, forceSync, verbose, useHostDNS); err != nil {
 		plog.Fatalf("repo sync failed: %v", err)
 	}
 

--- a/sdk/repo.go
+++ b/sdk/repo.go
@@ -154,10 +154,13 @@ func RepoVerifyTag(branch string) error {
 	return tag.Run()
 }
 
-func RepoSync(chroot string, force, useHostDNS bool) error {
+func RepoSync(chroot string, force, verbose, useHostDNS bool) error {
 	args := []string{"--", "repo", "sync", "--no-clone-bundle"}
 	if force {
 		args = append(args, "--force-sync")
+	}
+	if !verbose {
+		args = append(args, "--quiet")
 	}
 	return enterChroot(enter{
 		Chroot:     chroot,


### PR DESCRIPTION
The messages are long and scroll by too fast to be of any use to users. Adding
quiet turns it into a nice progress indicator.