### PR TITLE
kola/test/selinux: exclude `arm64` architecture

### DIFF
--- a/kola/tests/misc/selinux.go
+++ b/kola/tests/misc/selinux.go
@@ -26,16 +26,18 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:         SelinuxEnforce,
-		ClusterSize: 1,
-		Name:        "coreos.selinux.enforce",
-		Distros:     []string{"cl", "fcos", "rhcos"},
+		Run:           SelinuxEnforce,
+		ClusterSize:   1,
+		Name:          "coreos.selinux.enforce",
+		Distros:       []string{"cl", "fcos", "rhcos"},
+		Architectures: []string{"amd64"},
 	})
 	register.Register(&register.Test{
-		Run:         SelinuxBoolean,
-		ClusterSize: 1,
-		Name:        "coreos.selinux.boolean",
-		Distros:     []string{"cl", "fcos", "rhcos"},
+		Run:           SelinuxBoolean,
+		ClusterSize:   1,
+		Name:          "coreos.selinux.boolean",
+		Distros:       []string{"cl", "fcos", "rhcos"},
+		Architectures: []string{"amd64"},
 	})
 	register.Register(&register.Test{
 		Run:         SelinuxBooleanPersist,


### PR DESCRIPTION
SELinux is currently not yet available on ARM64 - there is an effort
to enable SELinux in this PR: https://github.com/kinvolk/coreos-overlay/pull/135.

Since the recent SELinux upgrades, we will need to rework a bit the PR.

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>
