### PR TITLE
kola: Use github container registry for test images

### DIFF
--- a/kola/tests/coretest/core.go
+++ b/kola/tests/coretest/core.go
@@ -155,7 +155,7 @@ func TestDockerEcho() error {
 	//t.Parallel()
 	errc := make(chan error, 1)
 	go func() {
-		c := exec.Command("docker", "run", "busybox", "echo")
+		c := exec.Command("docker", "run", "ghcr.io/kinvolk/busybox", "echo")
 		err := c.Run()
 		errc <- err
 	}()
@@ -174,7 +174,7 @@ func TestDockerPing() error {
 	//t.Parallel()
 	errc := make(chan error, 1)
 	go func() {
-		c := exec.Command("docker", "run", "busybox", "ping", "-c4", "coreos.com")
+		c := exec.Command("docker", "run", "ghcr.io/kinvolk/busybox", "ping", "-c4", "coreos.com")
 		err := c.Run()
 		errc <- err
 	}()

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -645,7 +645,7 @@ func dockerSELinux(c cluster.TestCluster) {
 	var cmd string
 
 	cmd = `sudo mkdir /etc/misc && \
-docker run -v "/etc/misc:/opt" --rm busybox true`
+docker run -v "/etc/misc:/opt" --rm ghcr.io/kinvolk/busybox true`
 
 	// assert SELinux is in permissive mode
 	if err := c.MustSSH(m, "sudo setenforce 0"); err != nil {
@@ -663,12 +663,12 @@ docker run -v "/etc/misc:/opt" --rm busybox true`
 	}
 
 	// run docker command to assert it fails because of wrong labeling
-	if _, err := c.SSH(m, `docker run -v "/etc/misc:/opt" --rm busybox sh -c "echo world > /opt/hello"`); err == nil {
+	if _, err := c.SSH(m, `docker run -v "/etc/misc:/opt" --rm ghcr.io/kinvolk/busybox sh -c "echo world > /opt/hello"`); err == nil {
 		c.Fatalf("command should raise a permission error")
 	}
 
 	// run docker command with correct relabel action (z)
-	if err := c.MustSSH(m, `docker run -v "/etc/misc:/opt:z" --rm busybox sh -c "echo world > /opt/hello"`); err != nil {
+	if err := c.MustSSH(m, `docker run -v "/etc/misc:/opt:z" --rm ghcr.io/kinvolk/busybox sh -c "echo world > /opt/hello"`); err != nil {
 		c.Fatalf("unable to run docker command: %v", err)
 	}
 

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -222,7 +222,7 @@ storage:
               spec:
                 containers:
                 - name: nginx
-                  image: nginx
+                  image: ghcr.io/kinvolk/nginx
                   ports:
                   - containerPort: 80`
 

--- a/kola/tests/kubernetes/basic.go
+++ b/kola/tests/kubernetes/basic.go
@@ -160,7 +160,7 @@ metadata:
 spec:
   containers:
   - name: nginx
-    image: nginx
+    image: ghcr.io/kinvolk/nginx
     ports:
     - containerPort: 80
     volumeMounts:


### PR DESCRIPTION
# Use github container registry for test imagees
We're hitting dockerhub pull rate limits in our CI. Most frequently it occurs with busybox and nginx images so I've mirrored those first. The nginx one is probably going to be pulled most often: the kubeadm tests run for 3 CNIs and multiple nodes each.

The mirroring was done with the following script:
```bash
#!/bin/bash

image=$1

platforms=( amd64 arm64 )
tags=()

for platform in "${platforms[@]}"; do
  var=$(docker pull $image --platform=$platform -q)
  tag=ghcr.io/kinvolk/$image:latest-$platform
  docker tag $var $tag
  docker push $tag
  tags+=( $tag )
done

docker manifest create ghcr.io/kinvolk/$image:latest "${tags[@]}"
docker manifest push --purge ghcr.io/kinvolk/$image:latest
```

## Testing done

`./bin/kola run --channel=alpha cl.internet docker.selinux`