### PR TITLE
test: fixes for ARM64

### DIFF
--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -417,7 +417,6 @@ func dockerUserns(c cluster.TestCluster) {
 
 	genDockerContainer(c, m, "userns-test", []string{"echo", "sleep"})
 
-	c.MustSSH(m, `sudo setenforce 1`)
 	output := c.MustSSH(m, `docker run userns-test echo fj.fj`)
 	if !bytes.Equal(output, []byte("fj.fj")) {
 		c.Fatalf("expected fj.fj, got %s", string(output))

--- a/platform/qemu.go
+++ b/platform/qemu.go
@@ -266,7 +266,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-aarch64",
 			"-machine", "virt",
 			"-cpu", "cortex-a57",
-			"-m", "2048",
+			"-m", "2512",
 		}
 	case "arm64--amd64-usr":
 		qmBinary = "qemu-system-x86_64"
@@ -282,7 +282,7 @@ func CreateQEMUCommand(board, uuid, biosImage, consolePath, confPath, diskImageP
 			"qemu-system-aarch64",
 			"-machine", "virt,accel=kvm,gic-version=3",
 			"-cpu", "host",
-			"-m", "2048",
+			"-m", "2512",
 		}
 	default:
 		panic("host-guest combo not supported: " + combo)


### PR DESCRIPTION
In this PR, we pull two fixes for ARM64 tests suite:

- increase the memory for QEMU tests - otherwise `torcx` was randomly failing to unpack Docker (-> no Docker)
- remove the explicit `setenforce 1` in `docker.userns` test (see the commit body for the `why?`)