### PR TITLE
etcdctl: use v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ By default, kola uses the `qemu` platform with the most recently built image
 (assuming it is run from within the SDK).
 
 #### kola run
+
+In order to provide internet access to QEMU instances; it's required to enable ipv4 forwarding on the host machine:
+
+```shell
+sudo sysctl -w net.ipv4.ip_forward=1
+```
+
 The run command invokes the main kola test harness. It
 runs any tests whose registered names matches a glob pattern.
 

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -80,21 +80,9 @@ etcd:
 func Discovery(c cluster.TestCluster) {
 	var err error
 
-	// NOTE(pb): this check makes the next code somewhat redundant
 	if err = GetClusterHealth(c, c.Machines()[0], len(c.Machines())); err != nil {
 		c.Fatalf("discovery failed cluster-health check: %v", err)
 	}
-
-	var keyMap map[string]string
-	keyMap, err = setKeys(c, 5)
-	if err != nil {
-		c.Fatalf("failed to set keys: %v", err)
-	}
-
-	if err = checkKeys(c, keyMap); err != nil {
-		c.Fatalf("failed to check keys: %v", err)
-	}
-
 }
 
 // etcdMemberV2BackupRestore tests that the basic etcdctl v2 operations (get,

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -114,6 +114,7 @@ func etcdMemberV2BackupRestore(c cluster.TestCluster) {
 	c.MustSSH(m, `
 	set -e
 
+	export ETCDCTL_API=2
 	prefix=$RANDOM
 	etcdctl set /$prefix/test magic
 	res="$(etcdctl get /$prefix/test)"


### PR DESCRIPTION
Most of the tests rely on `etcd` and use the `GetClusterHealth` method to ensure the etcd cluster is up and running. In this [PR](https://github.com/kinvolk/coreos-overlay/pull/1179); we upgraded `etcd` and it [seems](https://github.com/etcd-io/etcd/commit/25bc65794f6802cb24b40c3a46de9ab3fa5f9e6b) now the default `etcdctl` version is V3.

It should fix the following tests:
- cl.etcd-member.discovery
- cl.etcd-member.v2-backup-restore
- google.kubernetes.basic.docker.v1.18.0
- google.kubernetes.basic.docker.v1.16.8
- google.kubernetes.basic.docker.v1.14.10
- cl.locksmith.cluster
- coreos.locksmith.tls
- cl.etcd-member.etcdctlv3
- kubeadm.*

## Note for the reviewers

I first attended to support both v2/v3 but it becomes quickly an unmaintainable mess - so I removed the `setKeys` / `checkKeys` from the `cl.etcd-member.discovery`. REST APIs from v2 to v3 are not the same at all + v3 APIs between 3.3.35 (current etcd version that we ship) and 3.5 does not have the same prefix neither... Since this check is quite redundant with the others who are using `etcdctl` directly we can safely remove it.  

## How to use

```shell
sudo ./bin/kola run --board arm64-usr qemu --qemu-image flatcar_production_image.bin --qemu-bios flatcar_production_qemu_uefi_efi_code.fd cl.etcd-member.discovery ...
```

## Testing done

* alpha-2969.0.0 (amd64): `cl.etcd-member.discovery`
* the ARM64 image from https://github.com/kinvolk/coreos-overlay/pull/1179: `cl.etcd-member.discovery`