### PR TITLE
kola/tests/etcd: bind :2379 on all interfaces

### DIFF
--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -48,7 +48,7 @@ func init() {
 		UserData: conf.ContainerLinuxConfig(`
 
 etcd:
-  listen_client_urls:          http://0.0.0.0:4001,http://{PRIVATE_IPV4}:2379
+  listen_client_urls:          http://0.0.0.0:4001,http://0.0.0.0:2379
   advertise_client_urls:       http://{PRIVATE_IPV4}:2379
   listen_peer_urls:            http://0.0.0.0:2380
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380


### PR DESCRIPTION
with `etcdctl/v3` default endpoints is: 127.0.0.1:2379 while with
`etcdct/v2` it's http://127.0.0.1:2379,http://127.0.0.1:4001.
`etcdct/v3` was failing to reach `127.0.0.1:2379` because it's bound
to the private IPv4 (so `10.0.0.x`) (see also other tests: https://github.com/kinvolk/mantle/blob/flatcar-master/kola/tests/etcd/discovery.go#L35)

Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

## How to use

```
git checkout tormath1/fix-etcd-v2-restore
./build kola
sudo ./bin/kola run ...  cl.etcd-member.v2-backup-restore
```

## Testing done

:arrow_up: 