### PR TITLE
etcd: enable `v2` support for various tests

### DIFF
--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -121,7 +121,7 @@ func etcdMemberV2BackupRestore(c cluster.TestCluster) {
 
 	backup_to="$(mktemp -d)"
 
-	sudo etcdctl backup --data-dir=/var/lib/etcd \
+	sudo --preserve-env=ETCDCTL_API etcdctl backup --data-dir=/var/lib/etcd \
 	               --backup-dir "${backup_to}"
 	
 	etcdctl rm /$prefix/test

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -53,7 +53,15 @@ etcd:
   listen_peer_urls:            http://0.0.0.0:2380
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery
-`),
+systemd:
+  units:
+    - name: etcd-member.service
+      enabled: true
+      dropins:
+        - name: 10-enable-v2.conf
+          contents: |
+            [Service]
+            Environment=ETCD_ENABLE_V2=true`),
 		ExcludePlatforms: []string{"esx", "qemu-unpriv"}, // etcd-member requires ct rendering and networking
 		Distros:          []string{"cl"},
 	})

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -54,7 +54,16 @@ systemd:
         - name: 50-network-config.conf
           contents: |
             [Service]
-            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ \"Network\": \"10.254.0.0/16\", \"Backend\": {\"Type\": \"$type\"} }'`)
+            # to be changed when flannel will support etcd/V3
+            Environment=ETCDCTL_API=2
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ \"Network\": \"10.254.0.0/16\", \"Backend\": {\"Type\": \"$type\"} }'
+    - name: etcd-member.service
+      enabled: true
+      dropins:
+        - name: 10-enable-v2.conf
+          contents: |
+            [Service]
+            Environment=ETCD_ENABLE_V2=true`)
 )
 
 func init() {

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -74,6 +74,7 @@ func init() {
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 		UserData:         flannelConf.Subst("$type", "udp"),
+		Architectures:    []string{"amd64"},
 	})
 
 	register.Register(&register.Test{

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -44,7 +44,16 @@ etcd:
   advertise_client_urls:       http://{PRIVATE_IPV4}:2379
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   listen_peer_urls:            http://{PRIVATE_IPV4}:2380
-  discovery:                   $discovery`),
+  discovery:                   $discovery
+systemd:
+  units:
+    - name: etcd-member.service
+      enabled: true
+      dropins:
+        - name: 10-enable-v2.conf
+          contents: |
+            [Service]
+            Environment=ETCD_ENABLE_V2=true`),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
@@ -70,7 +79,7 @@ etcd:
         "name": "etcd-member.service",
         "dropins": [{
           "name": "environment.conf",
-          "contents": "[Unit]\nAfter=certgen.service\nRequires=certgen.service\n[Service]\nEnvironment=ETCD_ADVERTISE_CLIENT_URLS=https://127.0.0.1:2379\nEnvironment=ETCD_LISTEN_CLIENT_URLS=https://127.0.0.1:2379\nEnvironment=ETCD_CERT_FILE=/etc/ssl/certs/etcd-cert.pem\nEnvironment=ETCD_KEY_FILE=/etc/ssl/certs/etcd-key.pem\nEnvironment=ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/ca-locksmith-cert.pem\nEnvironment=ETCD_CLIENT_CERT_AUTH=true"
+          "contents": "[Unit]\nAfter=certgen.service\nRequires=certgen.service\n[Service]\nEnvironment=ETCD_ADVERTISE_CLIENT_URLS=https://127.0.0.1:2379\nEnvironment=ETCD_LISTEN_CLIENT_URLS=https://127.0.0.1:2379\nEnvironment=ETCD_CERT_FILE=/etc/ssl/certs/etcd-cert.pem\nEnvironment=ETCD_KEY_FILE=/etc/ssl/certs/etcd-key.pem\nEnvironment=ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/ca-locksmith-cert.pem\nEnvironment=ETCD_CLIENT_CERT_AUTH=true\nEnvironment=ETCD_ENABLE_V2=true"
         }]
       },
       {


### PR DESCRIPTION
In this PR, we prepare the landing of https://github.com/kinvolk/coreos-overlay/pull/1179 which brings `etcd/v3` by default.

- `flannel` does not support yet `etcd/v3` so we enable `v2` support
- `locksmith` is [WIP](https://github.com/kinvolk/locksmith/pull/12) to support `etcd/v3`
- `cl.etcd-member.v2-backup-restore` test the actual behavior of `v2` backup so it requires `v2` to be enabled

`v2` support is done through this option: https://etcd.io/docs/v3.5/op-guide/configuration/#--enable-v2

## Testing done

Tested against the current `alpha` and the image provided in https://github.com/kinvolk/coreos-overlay/pull/1179 (arm64 in progress...)
```
sudo ./bin/kola run ... cl.etcd-member.v2-backup-restore cl.locksmith.cluster coreos.locksmith.tls cl.flannel.udp cl.flannel.vxlan
```
