### PR TITLE
plaform/util: enable SELinux for all arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 ### Added
 ### Changed
+- Enabled SELinux for ARM64 ([#222](https://github.com/kinvolk/mantle/pull/222/))
+
 ### Removed
 
 ## [0.16.0] - 30/08/2021

--- a/kola/tests/misc/selinux.go
+++ b/kola/tests/misc/selinux.go
@@ -26,18 +26,16 @@ import (
 
 func init() {
 	register.Register(&register.Test{
-		Run:           SelinuxEnforce,
-		ClusterSize:   1,
-		Name:          "coreos.selinux.enforce",
-		Distros:       []string{"cl", "fcos", "rhcos"},
-		Architectures: []string{"amd64"},
+		Run:         SelinuxEnforce,
+		ClusterSize: 1,
+		Name:        "coreos.selinux.enforce",
+		Distros:     []string{"cl", "fcos", "rhcos"},
 	})
 	register.Register(&register.Test{
-		Run:           SelinuxBoolean,
-		ClusterSize:   1,
-		Name:          "coreos.selinux.boolean",
-		Distros:       []string{"cl", "fcos", "rhcos"},
-		Architectures: []string{"amd64"},
+		Run:         SelinuxBoolean,
+		ClusterSize: 1,
+		Name:        "coreos.selinux.boolean",
+		Distros:     []string{"cl", "fcos", "rhcos"},
 	})
 	register.Register(&register.Test{
 		Run:         SelinuxBooleanPersist,

--- a/platform/util.go
+++ b/platform/util.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"os"
-	"strings"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal"
@@ -130,9 +129,7 @@ func StartMachine(m Machine, j *Journal) error {
 	if err := CheckMachine(context.TODO(), m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
 	}
-	// Exclude ARM64 because we don't embeed SELinux tools
-	arch := strings.SplitN(m.Board(), "-", 2)[0]
-	if arch != "arm64" && !m.RuntimeConf().NoEnableSelinux {
+	if !m.RuntimeConf().NoEnableSelinux {
 		if err := EnableSelinux(m); err != nil {
 			return fmt.Errorf("machine %q failed to enable selinux: %v", m.ID(), err)
 		}


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mathieu@kinvolk.io>

Since `arm64` is going to support `SELinux`, there is no more need to not enable SELinux for `arm64` in the tests runtime.

Note: all the test will enable SELinux for `arm64`, we need to find a way to prevent channel != alpha to enable SELinux, otherwise all tests will fail until `SELinux/arm64` lands into `stable`.

## How to use

related to: https://github.com/kinvolk/coreos-overlay/pull/1245
## Testing done

n/a