### PR TITLE
kola/test/docker: enable `docker.selinux` for all arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Enabled SELinux for ARM64 ([#222](https://github.com/kinvolk/mantle/pull/222/))
+- Enabled `docker.selinux` test for ARM64 ([#225](https://github.com/kinvolk/mantle/pull/225))
 
 ### Removed
 

--- a/kola/tests/docker/docker.go
+++ b/kola/tests/docker/docker.go
@@ -55,12 +55,11 @@ type simplifiedDockerInfo struct {
 
 func init() {
 	register.Register(&register.Test{
-		Run:           dockerSELinux,
-		ClusterSize:   1,
-		Name:          "docker.selinux",
-		Distros:       []string{"cl"},
-		Channels:      []string{"alpha", "beta"},
-		Architectures: []string{"amd64"},
+		Run:         dockerSELinux,
+		ClusterSize: 1,
+		Name:        "docker.selinux",
+		Distros:     []string{"cl"},
+		MinVersion:  semver.Version{Major: 2942},
 	})
 	register.Register(&register.Test{
 		Run:         dockerNetwork,


### PR DESCRIPTION
SELinux is now supported on ARM64

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

## Testing done

```
# get image from SELinux PR https://github.com/kinvolk/coreos-overlay/pull/1245
wget https://storage.googleapis.com/flatcar-jenkins/developer/developer/boards/arm64-usr/2021.09.01%2Bdev-flatcar-master-3470/flatcar_production_image.bin.bz2
sudo ./bin/kola run --channel alpha --board arm64-usr --key ${HOME}/.ssh/id_rsa.pub -k -b cl --qemu-bios ./flatcar_production_qemu_uefi_efi_code.fd  -p qemu --qemu-image ./flatcar_production_image.bin docker.selinux
```