### PR TITLE
kola/test: use clc to set `enable_v2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enabled SELinux for ARM64 ([#222](https://github.com/kinvolk/mantle/pull/222/))
 - Enabled `docker.selinux` test for ARM64 ([#225](https://github.com/kinvolk/mantle/pull/225))
 - Fixed `amd64` checksums for Kubernetes `v1.21.0` tests ([#226](https://github.com/kinvolk/mantle/pull/226))
+- Used `clc` to set `enable_v2` option ([#227](https://github.com/kinvolk/mantle/pull/227))
 
 ### Removed
 

--- a/kola/tests/etcd/discovery.go
+++ b/kola/tests/etcd/discovery.go
@@ -48,20 +48,13 @@ func init() {
 		UserData: conf.ContainerLinuxConfig(`
 
 etcd:
+  version:                     3.5.0
   listen_client_urls:          http://0.0.0.0:4001,http://0.0.0.0:2379
   advertise_client_urls:       http://{PRIVATE_IPV4}:2379
   listen_peer_urls:            http://0.0.0.0:2380
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery
-systemd:
-  units:
-    - name: etcd-member.service
-      enabled: true
-      dropins:
-        - name: 10-enable-v2.conf
-          contents: |
-            [Service]
-            Environment=ETCD_ENABLE_V2=true`),
+  enable_v2:                   true`),
 		ExcludePlatforms: []string{"esx", "qemu-unpriv"}, // etcd-member requires ct rendering and networking
 		Distros:          []string{"cl"},
 	})

--- a/kola/tests/flannel/flannel.go
+++ b/kola/tests/flannel/flannel.go
@@ -31,11 +31,13 @@ import (
 
 var (
 	flannelConf = conf.ContainerLinuxConfig(`etcd:
+  version:                     3.5.0
   discovery:                   $discovery
   listen_client_urls:          http://0.0.0.0:2379
   advertise_client_urls:       http://{PRIVATE_IPV4}:2379
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   listen_peer_urls:            http://{PRIVATE_IPV4}:2380
+  enable_v2:                   true
 systemd:
   units:
     - name: flannel-docker-opts.service
@@ -56,14 +58,7 @@ systemd:
             [Service]
             # to be changed when flannel will support etcd/V3
             Environment=ETCDCTL_API=2
-            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ \"Network\": \"10.254.0.0/16\", \"Backend\": {\"Type\": \"$type\"} }'
-    - name: etcd-member.service
-      enabled: true
-      dropins:
-        - name: 10-enable-v2.conf
-          contents: |
-            [Service]
-            Environment=ETCD_ENABLE_V2=true`)
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ \"Network\": \"10.254.0.0/16\", \"Backend\": {\"Type\": \"$type\"} }'`)
 )
 
 func init() {

--- a/kola/tests/locksmith/locksmith.go
+++ b/kola/tests/locksmith/locksmith.go
@@ -40,20 +40,13 @@ func init() {
 		UserData: conf.ContainerLinuxConfig(`locksmith:
   reboot_strategy: etcd-lock
 etcd:
+  version:                     3.5.0
   listen_client_urls:          http://0.0.0.0:2379
   advertise_client_urls:       http://{PRIVATE_IPV4}:2379
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
   listen_peer_urls:            http://{PRIVATE_IPV4}:2380
   discovery:                   $discovery
-systemd:
-  units:
-    - name: etcd-member.service
-      enabled: true
-      dropins:
-        - name: 10-enable-v2.conf
-          contents: |
-            [Service]
-            Environment=ETCD_ENABLE_V2=true`),
+  enable_v2:                   true`),
 		Distros:          []string{"cl"},
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})


### PR DESCRIPTION
In 12b5a96ee4099cc3c2dbe4af35ebbfc55b13868a, we enabled the V2 support
for `etcd`. It means that `etcd` starts with support for both datastore
version.

Support has been enabled through a `systemd` dropin - this one will
generate a dropin under the `etcd-member.service` unit but
`container-linux-config` will generate a dropin under
`etcd-member.service` name too.

This is not an issue with `ignition/v2` but it is with `ignition/v3`
(see: https://github.com/kinvolk/ignition/blob/main/docs/configuration-v3_0.md).

So we need to add the `enable_v2` direcly into the `clc` - `enable_v2`
is present in `clc` from `config.Types.Etcd3_2` but by default it
targets `3.0.0` so we need to pin the version to the current tested one
(`3.5.0`) to use `enable_v2` and the correct image tag.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

## Testing done
```
sudo ./bin/kola run --key ${HOME}/.ssh/id_rsa.pub -k -b cl -p qemu --qemu-image /home/mathieu/kinvolk/alpha/flatcar_production_qemu_image.img -j 1 cl.locksmith.cluster cl.etcd-member.v2-backup-restore cl.flannel.udp cl.flannel.vxlan
```


## Note for reviewers

CLC needs to be [upgraded](https://github.com/kinvolk/Flatcar/issues/398) to support `etcd>3.3.0` - it's not an issue at the moment for the tests except this warnings:
```
2021-09-06T08:50:24Z platform/conf: parsing Container Linux config: warning at line 4, column 32
Etcd minor version specified is too new, only options available in the previous minor version will be accepted
```

but we won't be able to use particular options from `etcd>3.3.0` in the future tests.