### PR TITLE
kola/kubeadm/tmpl: forward docker logs to journald

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Security
 ### Added
 - `kubeadm` proper support for ARM64 ([#217](https://github.com/kinvolk/mantle/pull/217))
+- docker logs forwarding to `journald` for `kubeadm.*` tests ([#228](https://github.com/kinvolk/mantle/pull/228))
 
 ### Changed
 - Enabled SELinux for ARM64 ([#222](https://github.com/kinvolk/mantle/pull/222/))

--- a/kola/tests/kubeadm/templates.go
+++ b/kola/tests/kubeadm/templates.go
@@ -96,7 +96,15 @@ storage:
       mode: 0755
       contents:
         remote:
-          url: "data:text/plain;base64,{{ .WorkerScript }}"`
+          url: "data:text/plain;base64,{{ .WorkerScript }}"
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+              "log-driver": "journald"
+          }`
 
 	masterConfig = `systemd:
   units:
@@ -185,6 +193,14 @@ storage:
             hash:
               function: sha512
               sum: {{ index (index . .Arch) "KubectlSum" }}
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+              "log-driver": "journald"
+          }
 {{ if eq .CNI "cilium" }}
     - path: {{ .DownloadDir }}/cilium.tar.gz
       filesystem: root

--- a/kola/tests/kubeadm/testdata/master-cilium-amd64-config.yml
+++ b/kola/tests/kubeadm/testdata/master-cilium-amd64-config.yml
@@ -85,6 +85,14 @@ storage:
             hash:
               function: sha512
               sum: a93b2ca067629cb1fe9cbf1af1a195c12126488ed321e3652200d4dbfee9a577865647b7ef6bb673e1bdf08f03108b5dcb4b05812a649a0de5c7c9efc1407810
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+              "log-driver": "journald"
+          }
 
     - path: /opt/bin/cilium.tar.gz
       filesystem: root

--- a/kola/tests/kubeadm/testdata/master-cilium-arm64-config.yml
+++ b/kola/tests/kubeadm/testdata/master-cilium-arm64-config.yml
@@ -85,6 +85,14 @@ storage:
             hash:
               function: sha512
               sum: b990b81d5a885a9d131aabcc3a5ca9c37dfaff701470f2beb896682a8643c7e0c833e479a26f21129b598ac981732bf52eecdbe73896fe0ff2d9c1ffd082d1fd
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+              "log-driver": "journald"
+          }
 
     - path: /opt/bin/cilium.tar.gz
       filesystem: root


### PR DESCRIPTION
this can help debugging failing tests.
See also: https://docs.docker.com/config/containers/logging/journald/

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

For ARM64, tests are failing and only indications we have are from kubelet:
```
Sep  7 09:22:43.120921 kubelet[1354]: E0907 09:22:43.120852    1354 pod_workers.go:747] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"ebpf-mount\" with CrashLoopBackOff: \"back-off 1m20s restarting failed container=ebpf-mount pod=cilium-g84j6_kube-system(aa57d085-b710-4447-b704-550e59266eee)\"" pod="kube-system/cilium-g84j6" podUID=aa57d085-b710-4447-b704-550e59266eee
```
## How to use

- run a `kubeadm.*` test
- check logs into `_kola_temp/.../journal.txt`:
```shell
Sep  7 15:41:10.780613 kernel: IPVS: [rr] scheduler registered.
Sep  7 15:41:10.786475 kernel: IPVS: [wrr] scheduler registered.
Sep  7 15:41:10.793491 kernel: IPVS: [sh] scheduler registered.
Sep  7 15:41:10.822230 6d438354cb89[1103]: I0907 13:41:10.821885       1 node.go:172] Successfully retrieved node IP: 10.0.0.3
Sep  7 15:41:10.822776 6d438354cb89[1103]: I0907 13:41:10.821982       1 server_others.go:140] Detected node IP 10.0.0.3
Sep  7 15:41:10.822930 6d438354cb89[1103]: W0907 13:41:10.822038       1 server_others.go:598] Unknown proxy mode "", assuming iptables proxy
Sep  7 15:41:10.876805 6d438354cb89[1103]: I0907 13:41:10.876354       1 server_others.go:206] kube-proxy running in dual-stack mode, IPv4-primary
Sep  7 15:41:10.878064 6d438354cb89[1103]: I0907 13:41:10.876530       1 server_others.go:212] Using iptables Proxier.
Sep  7 15:41:10.878299 6d438354cb89[1103]: I0907 13:41:10.876593       1 server_others.go:219] creating dualStackProxier for iptables.
...
```

docker containers logs are now redirected to journald.

