### PR TITLE
kola/misc/network: support various network service description

### DIFF
--- a/kola/tests/misc/network.go
+++ b/kola/tests/misc/network.go
@@ -162,7 +162,10 @@ func NetworkInitramfsSecondBoot(c cluster.TestCluster) {
 	// verify that the network service was started
 	found := false
 	for _, line := range lines {
-		if line == "Started Network Service." {
+		// Once systemd totally upgraded to > 248, we can safely remove the `line == "Started Network Service."` section.
+		// In v249, some services description have been updated.
+		// More details: https://github.com/systemd/systemd/commit/4fd3fc66396026f81fd5b27746f2faf8a9a7b9ee
+		if line == "Started Network Service." || line == "Started Network Configuration." {
 			found = true
 			break
 		}


### PR DESCRIPTION
Starting from systemd-v249, some services description have changed which leads to
test failure since we rely on the exact string matches for this test.

Note: I don't think a changelog entry is relevant for this change.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>