### PR TITLE
kola/test/kubeadm: remove duplicate etcd-member entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bumped `CiliumCLI` version to pull `Cilium-1.10.4` ([#240](https://github.com/kinvolk/mantle/pull/230))
 
 ### Removed
+- Duplicated `etcd-member` in the `kubeadm.*` config ([#232](https://github.com/kinvolk/mantle/pull/232))
 
 ## [0.16.0] - 30/08/2021
 

--- a/kola/tests/kubeadm/kubeadm.go
+++ b/kola/tests/kubeadm/kubeadm.go
@@ -92,12 +92,7 @@ var (
 	etcdConfig = conf.ContainerLinuxConfig(`
 etcd:
   advertise_client_urls: http://{PRIVATE_IPV4}:2379
-  listen_client_urls: http://0.0.0.0:2379
-systemd:
-  units:
-    - name: etcd-member.service
-      enabled: true
-`)
+  listen_client_urls: http://0.0.0.0:2379`)
 )
 
 func init() {


### PR DESCRIPTION
`etcd` type from `clc` takes care of enabling the `etcd-member` unit -
there is no need to enable it "manually".

It's not an issue with `ignition/v2` but `ignition/v3` does not like
duplicate systemd dropin entries.

See: https://github.com/kinvolk/container-linux-config-transpiler/blob/flatcar-master/config/types/etcd.go#L136-L137

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
